### PR TITLE
Update relative path of contracts repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
         "cypress:run": "cypress run",
         "cypress:runrecord":
             "$(npm bin)/cypress run --record --key 42b3c18f-e1cf-4c27-85ed-c223e420bd4a",
-        "truffle:migrate": "cd augmint-contracts && npm run truffle:migrate",
+        "truffle:migrate": "cd ../augmint-contracts && npm run truffle:migrate",
         "truffle:migratecopy":
-            "cd augmint-contracts && npm run truffle:migrate && cp build/contracts/* ../src/contractsBuild && echo 'Copied contract artifacts from augmint-contracts/build/contracts to src/contractsBuild. Make sure you do not check in contracts build folder.' ",
+            "cd ../augmint-contracts && npm run truffle:migrate && cp build/contracts/* ../src/contractsBuild && echo 'Copied contract artifacts from augmint-contracts/build/contracts to src/contractsBuild. Make sure you do not check in contracts build folder.' ",
         "ganache:run": "cd augmint-contracts && npm run ganache:run",
         "ganache:runmigrate":
-            "cd augmint-contracts && npm run ganache:runmigrate"
+            "cd ../augmint-contracts && npm run ganache:runmigrate"
     },
     "devDependencies": {
         "cross-env": "5.1.3",


### PR DESCRIPTION
After splitting the app into two repos the direct path doesn't work since the scripts are running from `augmint-web`. These changes assume that both of the repos are located in the same folder as siblings:
```
foo/
├── augmint_web/
├── augmint_contracts/
```