### PR TITLE
Add precommit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "redux-thunk": "2.3.0",
     "redux-watch": "1.1.1",
     "stringifier": "1.3.0",
-    "styled-components": "3.3.0",
+    "styled-components": "3.3.3",
     "styled-components-grid": "2.0.1",
     "styled-system": "2.3.2",
-    "styled-tools": "0.5.0",
+    "styled-tools": "0.5.3",
     "styled-tooltip-component": "1.3.0",
     "web3": "1.0.0-beta.34"
   },

--- a/package.json
+++ b/package.json
@@ -43,12 +43,11 @@
     "eject": "react-scripts eject",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
-    "eslint:src": "./node_modules/.bin/eslint ./src/",
     "cypress:runrecord": "$(yarn bin)/cypress run --record --key 42b3c18f-e1cf-4c27-85ed-c223e420bd4a",
     "contracts:migrate": "cd augmint-contracts && yarn migrate",
     "ganache:run": "cd augmint-contracts && yarn ganache:run",
     "contracts:runmigrate": "cd augmint-contracts && yarn runmigrate",
-    "precommit": "yarn eslint:src && pretty-quick --staged"
+    "precommit": "pretty-quick --staged"
   },
   "devDependencies": {
     "cypress": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "redux-thunk": "2.3.0",
     "redux-watch": "1.1.1",
     "stringifier": "1.3.0",
-    "styled-tools": "0.5.3",
-    "styled-components": "3.3.3",
-    "styled-system": "2.3.2",
+    "styled-components": "3.3.0",
     "styled-components-grid": "2.0.1",
+    "styled-system": "2.3.2",
+    "styled-tools": "0.5.0",
     "styled-tooltip-component": "1.3.0",
     "web3": "1.0.0-beta.34"
   },
@@ -43,17 +43,23 @@
     "eject": "react-scripts eject",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
-    "cypress:runrecord":
-      "$(yarn bin)/cypress run --record --key 42b3c18f-e1cf-4c27-85ed-c223e420bd4a",
+    "eslint:src": "./node_modules/.bin/eslint ./src/",
+    "cypress:runrecord": "$(yarn bin)/cypress run --record --key 42b3c18f-e1cf-4c27-85ed-c223e420bd4a",
     "contracts:migrate": "cd augmint-contracts && yarn migrate",
     "ganache:run": "cd augmint-contracts && yarn ganache:run",
-    "contracts:runmigrate": "cd augmint-contracts && yarn runmigrate"
+    "contracts:runmigrate": "cd augmint-contracts && yarn runmigrate",
+    "precommit": "yarn eslint:src && pretty-quick --staged"
   },
   "devDependencies": {
     "cypress": "3.0.1",
-    "eslint-plugin-cypress": "2.0.1"
+    "eslint-plugin-cypress": "2.0.1",
+    "husky": "0.14.3",
+    "prettier": "1.13.6",
+    "pretty-quick": "1.6.0"
   },
   "greenkeeper": {
-    "ignore": ["bignumber.js"]
+    "ignore": [
+      "bignumber.js"
+    ]
   }
 }

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "react-app",
   "rules": {
-    max-len: "off"
+    "max-len": "off",
+    "no-unused-vars": "error"
   }
 }

--- a/src/components/navigation/index.js
+++ b/src/components/navigation/index.js
@@ -38,7 +38,7 @@ export default class AppMenu extends React.Component {
     }
 
     render() {
-        const { isConnected, network } = this.props.web3Connect;
+        const { isConnected } = this.props.web3Connect;
         const { location } = this.props;
 
         const currentLocation = location.pathname;
@@ -68,7 +68,12 @@ export default class AppMenu extends React.Component {
                             </AppMenuItem>
                         </StyleNavList>
                     </StyledNavLeftSide>
-                    <Button type="a" data-testid="useAEurButton" to={ !showConnection && isConnected ? "/account" : "/tryit" } color="primary">
+                    <Button
+                        type="a"
+                        data-testid="useAEurButton"
+                        to={!showConnection && isConnected ? "/account" : "/tryit"}
+                        color="primary"
+                    >
                         My Account
                     </Button>
                     {showConnection && !isConnected && <div>Not connected</div>}

--- a/src/containers/account/components/TransferList.js
+++ b/src/containers/account/components/TransferList.js
@@ -5,8 +5,6 @@ import { ErrorPanel } from "components/MsgPanels";
 import { MoreInfoTip } from "components/ToolTip";
 import AccountAddress from "components/accountAddress";
 
-import { shortAccountAddresConverter } from "utils/converter";
-
 export default class TransferList extends React.Component {
     render() {
         const { filter, header, noItemMessage, userAccountAddress } = this.props;

--- a/src/containers/lock/components/ReleaseFundsButton.js
+++ b/src/containers/lock/components/ReleaseFundsButton.js
@@ -46,7 +46,6 @@ export default class ReleaseLockButton extends React.Component {
     }
 
     render() {
-        const { lockId } = this.props;
         const { submitting, submitSucceeded, error } = this.state;
 
         return (
@@ -72,11 +71,7 @@ export default class ReleaseLockButton extends React.Component {
 
                 {!error &&
                     !submitSucceeded && (
-                        <Button
-                            data-testid={`releaseLockButton`}
-                            disabled={submitting}
-                            onClick={this.submitCancel}
-                        >
+                        <Button data-testid={`releaseLockButton`} disabled={submitting} onClick={this.submitCancel}>
                             {submitting ? "Submitting..." : "Release funds"}
                         </Button>
                     )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6387,6 +6387,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@1.13.6:
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.6.tgz#00ae0b777ad92f81a9e7a1df2f0470b6dab0cb44"
+
 pretty-bytes@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"
@@ -7787,9 +7791,9 @@ styled-components-grid@2.0.1:
     react-create-component-from-tag-prop "^1.3.1"
     styled-components-breakpoint "^2.0.2"
 
-styled-components@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.3.3.tgz#09e702055ab11f7a8eab8229b1c0d0b855095686"
+styled-components@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.3.0.tgz#335b1b2b673b416cd5ec012010e237ed1f877fe9"
   dependencies:
     buffer "^5.0.3"
     css-to-react-native "^2.0.3"
@@ -7808,11 +7812,11 @@ styled-system@2.3.2:
   dependencies:
     prop-types "^15.6.0"
 
-styled-tools@0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/styled-tools/-/styled-tools-0.5.3.tgz#725b4a990c8dd43e628597eea9b22c444e7aec9c"
+styled-tools@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/styled-tools/-/styled-tools-0.5.0.tgz#3eaddb689f00ce8f8efd101b45eb14ce9e79e363"
   dependencies:
-    lodash "^4.17.10"
+    lodash "^4.17.4"
 
 styled-tooltip-component@1.3.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1590,7 +1590,7 @@ chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@2.4.1, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.1:
+chalk@2.4.1, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -3038,6 +3038,18 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 executable@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/executable/-/executable-4.1.1.tgz#41532bff361d3e57af4d763b70582db18f5d133c"
@@ -4011,6 +4023,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+husky@0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -4044,6 +4064,10 @@ ignore-walk@^3.0.1:
 ignore@^3.3.3:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.8.tgz#3f8e9c35d38708a3a7e0e9abb6c73e7ee7707b2b"
+
+ignore@^3.3.7:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
 
 import-lazy@^2.1.0:
   version "2.1.0"
@@ -5429,6 +5453,10 @@ mout@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/mout/-/mout-0.11.1.tgz#ba3611df5f0e5b1ffbfd01166b8f02d1f5fa2b99"
 
+mri@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.1.tgz#85aa26d3daeeeedf80dc5984af95cc5ca5cad9f1"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -5593,6 +5621,10 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
@@ -6372,6 +6404,16 @@ pretty-format@^20.0.3:
   dependencies:
     ansi-regex "^2.1.1"
     ansi-styles "^3.0.0"
+
+pretty-quick@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-1.6.0.tgz#afc3591eb5c4cf37614a305d489a8a40e57c9258"
+  dependencies:
+    chalk "^2.3.0"
+    execa "^0.8.0"
+    find-up "^2.1.0"
+    ignore "^3.3.7"
+    mri "^1.1.0"
 
 private@^0.1.6, private@^0.1.7, private@^0.1.8:
   version "0.1.8"
@@ -7718,6 +7760,10 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7791,9 +7791,9 @@ styled-components-grid@2.0.1:
     react-create-component-from-tag-prop "^1.3.1"
     styled-components-breakpoint "^2.0.2"
 
-styled-components@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.3.0.tgz#335b1b2b673b416cd5ec012010e237ed1f877fe9"
+styled-components@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.3.3.tgz#09e702055ab11f7a8eab8229b1c0d0b855095686"
   dependencies:
     buffer "^5.0.3"
     css-to-react-native "^2.0.3"
@@ -7812,11 +7812,11 @@ styled-system@2.3.2:
   dependencies:
     prop-types "^15.6.0"
 
-styled-tools@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/styled-tools/-/styled-tools-0.5.0.tgz#3eaddb689f00ce8f8efd101b45eb14ce9e79e363"
+styled-tools@0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/styled-tools/-/styled-tools-0.5.3.tgz#725b4a990c8dd43e628597eea9b22c444e7aec9c"
   dependencies:
-    lodash "^4.17.4"
+    lodash "^4.17.10"
 
 styled-tooltip-component@1.3.0:
   version "1.3.0"


### PR DESCRIPTION
1. After `git commit` changes:
- ~run eslint against the `/src` folder~
- run prettier against the whole repo and fix forward mismatching coding style

2. Add `"no-unused-vars": "error"` rule to `.eslintrc` to throw error instead of warning which we tend to overlook



