### PR TITLE
fix(TryItConnected): change <Link> to </a>

### DIFF
--- a/src/containers/home/tryIt/TryItConnected.js
+++ b/src/containers/home/tryIt/TryItConnected.js
@@ -23,15 +23,15 @@ export function TryItConnected(props) {
                     <Tblock header="Get some test ETH" headerStyle={"primaryColor"}>
                         <StyledP className={_className}>
                             Use{" "}
-                            <Link target="_blank" to="https://faucet.rinkeby.io/">
+                            <a href="https://faucet.rinkeby.io/" target="_blank">
                                 faucet.rinkeby.io
-                            </Link>
+                            </a>
                         </StyledP>
                         <StyledP className={_className}>
                             If you can't be bothered ask for some{" "}
-                            <Link target="_blank" to="https://discord.gg/PwDmsnu">
+                            <a href="https://discord.gg/PwDmsnu" target="_blank">
                                 on our discord channel
-                            </Link>
+                            </a>
                         </StyledP>
                         <Video
                             title="connect to rinkeby"


### PR DESCRIPTION
#### Nature of the PR: bug
#### Steps to reproduce:
- go to augmint.cc/tryit
- rinkeby.io & discord links in `Get some test ETH` section will NOT work
#### Trello card / screenshot / wireframe link:
- [Trello card](https://trello.com/c/ia9cCpth)
#### Is connection necessary to test? If so which network?
- [ ] local RPC
- [x] Rinkeby
- [ ] Main Ethereum Network
