### PR TITLE
fix(tryIt): add rel='noopener noreferrer' to 3 links

### DIFF
--- a/src/containers/home/tryIt/HowToConnect.js
+++ b/src/containers/home/tryIt/HowToConnect.js
@@ -48,7 +48,7 @@ export function HowToConnect(props) {
                             </StyledP>
                             <Header as="h4" className={"tertiaryColor"}>
                                 1. Install{" "}
-                                <a href="https://metamask.io" target="_blank">
+                                <a href="https://metamask.io" target="_blank" rel="noopener noreferrer">
                                     <strong>MetaMask Chrome plugin</strong>
                                 </a>
                             </Header>

--- a/src/containers/home/tryIt/TryItConnected.js
+++ b/src/containers/home/tryIt/TryItConnected.js
@@ -23,13 +23,13 @@ export function TryItConnected(props) {
                     <Tblock header="Get some test ETH" headerStyle={"primaryColor"}>
                         <StyledP className={_className}>
                             Use{" "}
-                            <a href="https://faucet.rinkeby.io/" target="_blank">
+                            <a href="https://faucet.rinkeby.io/" target="_blank" rel="noopener noreferrer">
                                 faucet.rinkeby.io
                             </a>
                         </StyledP>
                         <StyledP className={_className}>
                             If you can't be bothered ask for some{" "}
-                            <a href="https://discord.gg/PwDmsnu" target="_blank">
+                            <a href="https://discord.gg/PwDmsnu" target="_blank" rel="noopener noreferrer">
                                 on our discord channel
                             </a>
                         </StyledP>


### PR DESCRIPTION
#### Nature of the PR: bug
#### Steps to reproduce:
- see yarn start log for messages
#### Trello card / screenshot / wireframe link:
<img width="487" alt="screen shot 2018-07-23 at 19 32 52" src="https://user-images.githubusercontent.com/32713470/43128563-9607779e-8f32-11e8-8ca5-7fa3ead539c6.png">


#### Is connection necessary to test? If so which network?
- [ ] local RPC
- [ ] Rinkeby
- [ ] Main Ethereum Network
