### PR TITLE
Cancel order price rate fix

### DIFF
--- a/src/containers/exchange/components/CancelOrderButton.js
+++ b/src/containers/exchange/components/CancelOrderButton.js
@@ -13,6 +13,9 @@ import Modal from "components/augmint-ui/modal";
 import { cancelOrder, CANCEL_ORDER_SUCCESS, TOKEN_SELL, TOKEN_BUY } from "modules/reducers/orders";
 import { EthSubmissionErrorPanel } from "components/MsgPanels";
 
+import { DECIMALS } from "utils/constants";
+import { floatNumberConverter } from "utils/converter";
+
 import theme from "styles/theme";
 
 class CancelOrderButton extends React.Component {
@@ -59,6 +62,7 @@ class CancelOrderButton extends React.Component {
     render() {
         const { order, label = "Cancel" } = this.props;
         const { submitting, error, confirmOpen } = this.state;
+        const priceRate = floatNumberConverter(order.price, DECIMALS);
 
         return (
             <div style={{ display: "inline-block" }}>
@@ -112,12 +116,12 @@ class CancelOrderButton extends React.Component {
                             <p style={{ marginTop: "0" }}>Order id: {order.id}</p>
                             {order.direction === TOKEN_SELL && (
                                 <p>
-                                    Sell {order.amount} A-EUR @{order.price * 100}% EUR/ETH rate
+                                    Sell {order.amount} A-EUR @{priceRate}% EUR/ETH rate
                                 </p>
                             )}
                             {order.direction === TOKEN_BUY && (
                                 <p>
-                                    Buy A-EUR for {order.amount} ETH @{order.price * 100}% EUR/ETH rate
+                                    Buy A-EUR for {order.amount} ETH @{priceRate}% EUR/ETH rate
                                 </p>
                             )}
                             <p style={{ marginBottom: "0" }}>Are you sure you want to cancel your order?</p>


### PR DESCRIPTION
#### Nature of the PR: bug
#### Steps to reproduce:
create a buy/sell transaction with 100.5% price then cancel it
#### Trello card link:
https://trello.com/c/8JG5JIjU/224-javascript-float-issues-cancel-order-order-details
#### Is connection necessary to test? If so which network?
- [x] local RPC
- [x] Rinkeby
- [x] Main Ethereum Network
