### PR TITLE
don't show message alerts on reserves and underthehood pages

### DIFF
--- a/cypress/integration/augmintbasic.js
+++ b/cypress/integration/augmintbasic.js
@@ -2,11 +2,6 @@ describe("Augmint base", function() {
     it("Under the hood", function() {
         cy.get("[data-testid=underTheHoodLink]").click();
 
-        cy.get("[data-testid=dismissLegacyLoanManagerButton-0]").click();
-        cy.get("[data-testid=dismissLegacyLockerButton-0]").click();
-        cy.get("[data-testid=dismissLegacyBalanceButton-0]").click();
-        cy.get("[data-testid=dismissLegacyExchangeButton-0]").click();
-
         cy.get("[data-testid=baseInfoLink]").click();
         cy.get("[data-testid=web3ConnectionInfo]").contains("connected");
         cy.get("[data-testid=userAccountTokenBalance]").should("not.contain", "?");

--- a/src/containers/app/index.js
+++ b/src/containers/app/index.js
@@ -149,15 +149,16 @@ class App extends React.Component {
                 {showConnection && <SideNav showMenu={this.state.showMobileMenu} toggleMenu={this.toggleMenu} />}
 
                 <div className={showConnection ? "Site-content App-content" : "Site-content"}>
-                    {showConnection && (
-                        <div>
-                            <EthereumTxStatus />
-                            <LegacyLoanManagers />
-                            <LegacyLockers />
-                            <LegacyExchanges />
-                            <LegacyTokens />
-                        </div>
-                    )}
+                    {showConnection &&
+                        ["reserves", "under-the-hood"].indexOf(mainPath) < 0 && (
+                            <div>
+                                <EthereumTxStatus />
+                                <LegacyLoanManagers />
+                                <LegacyLockers />
+                                <LegacyExchanges />
+                                <LegacyTokens />
+                            </div>
+                        )}
 
                     <Switch>
                         <Route exact path="/" component={NotConnectedHome} />


### PR DESCRIPTION
#### Nature of the PR: chore
#### Steps to reproduce:
You need a user who has old contracts a-euro/loan/lock then go to reserves/underthehood page
#### Trello card link:
https://trello.com/c/cwFbl8d7/141-dont-show-message-alerts-on-reserves-and-underthehood-pages
#### Is connection necessary to test? If so which network?
- [x] local RPC
- [x] Rinkeby
- [ ] Main Ethereum Network
