### PR TITLE
fix(loan, lock): sorting

### DIFF
--- a/src/containers/loan/components/LoanList.js
+++ b/src/containers/loan/components/LoanList.js
@@ -10,14 +10,16 @@ export default function LoanList(props) {
     const listItems =
         loans &&
         loans
-            .reverse()
             .filter(props.filter ? props.filter : loan => loan.isRepayable)
             .map(loan => (
                 <MyListGroup.Row key={`loan-${loan.id}`}>
                     <LoanListDetails loan={loan} />
                     {props.selectComponent && <props.selectComponent loanId={loan.id} />}
                 </MyListGroup.Row>
-            ));
+            ))
+            .sort((a, b) => {
+                return a.props.children[0].props.loan.maturity - b.props.children[0].props.loan.maturity;
+            });
 
     return (
         <Pblock data-testid="LoanListBlock" loading={isLoading} header={props.header}>

--- a/src/containers/loan/components/LoanList.js
+++ b/src/containers/loan/components/LoanList.js
@@ -11,15 +11,15 @@ export default function LoanList(props) {
         loans &&
         loans
             .filter(props.filter ? props.filter : loan => loan.isRepayable)
+            .sort((a, b) => {
+                return a.maturity - b.maturity;
+            })
             .map(loan => (
                 <MyListGroup.Row key={`loan-${loan.id}`}>
                     <LoanListDetails loan={loan} />
                     {props.selectComponent && <props.selectComponent loanId={loan.id} />}
                 </MyListGroup.Row>
-            ))
-            .sort((a, b) => {
-                return a.props.children[0].props.loan.maturity - b.props.children[0].props.loan.maturity;
-            });
+            ));
 
     return (
         <Pblock data-testid="LoanListBlock" loading={isLoading} header={props.header}>

--- a/src/containers/loan/loanList/index.js
+++ b/src/containers/loan/loanList/index.js
@@ -15,12 +15,20 @@ function LoanList(props) {
     const { isLoading, error, loans } = props.loans;
     const isActivePage = location.pathname === "/loan";
 
+    console.log(loans);
+
     const listItems =
         loans &&
         loans
-            .reverse()
             .filter(loan => loan.isRepayable === isActivePage)
-            .map(loan => <LoanCard key={`loan-${loan.id}`} loan={loan} />);
+            .map(loan => <LoanCard key={`loan-${loan.id}`} loan={loan} />)
+            .sort((a, b) => {
+                return isActivePage
+                    ? a.props.loan.maturity - b.props.loan.maturity
+                    : b.props.loan.maturity - a.props.loan.maturity;
+            });
+
+    console.log(listItems);
 
     return (
         <Psegment>

--- a/src/containers/loan/loanList/index.js
+++ b/src/containers/loan/loanList/index.js
@@ -14,21 +14,14 @@ function LoanList(props) {
     const { location } = props;
     const { isLoading, error, loans } = props.loans;
     const isActivePage = location.pathname === "/loan";
-
-    console.log(loans);
-
     const listItems =
         loans &&
         loans
             .filter(loan => loan.isRepayable === isActivePage)
-            .map(loan => <LoanCard key={`loan-${loan.id}`} loan={loan} />)
             .sort((a, b) => {
-                return isActivePage
-                    ? a.props.loan.maturity - b.props.loan.maturity
-                    : b.props.loan.maturity - a.props.loan.maturity;
-            });
-
-    console.log(listItems);
+                return isActivePage ? a.maturity - b.maturity : b.maturity - a.maturity;
+            })
+            .map(loan => <LoanCard key={`loan-${loan.id}`} loan={loan} />);
 
     return (
         <Psegment>

--- a/src/containers/lock/components/LockList.jsx
+++ b/src/containers/lock/components/LockList.jsx
@@ -11,14 +11,14 @@ export default function LockList(props) {
         locks &&
         locks
             .filter(props.filter ? props.filter : lock => lock.isActive)
+            .sort((a, b) => {
+                return a.lockedUntil - b.lockedUntil;
+            })
             .map(lock => (
                 <MyListGroup.Row key={`lock-${lock.id}`}>
                     <LockListDetails lock={lock} />
                 </MyListGroup.Row>
-            ))
-            .sort((a, b) => {
-                return a.props.children.props.lock.lockedUntil - b.props.children.props.lock.lockedUntil;
-            });
+            ));
 
     return (
         <Pblock data-testid="LockListBlock" loading={isLoading} header={props.header}>

--- a/src/containers/lock/components/LockList.jsx
+++ b/src/containers/lock/components/LockList.jsx
@@ -7,16 +7,23 @@ import LockListDetails from "./LockListDetails";
 
 export default function LockList(props) {
     const { isLoading, error, locks } = props.locks;
+
+    console.log(locks);
+
     const listItems =
         locks &&
         locks
-            .filter(props.filter ? props.filter : lock => lock.isReleasebale || lock.isActive)
-            .map((lock, index) => (
+            .filter(props.filter ? props.filter : lock => lock.isActive)
+            .map(lock => (
                 <MyListGroup.Row key={`lock-${lock.id}`}>
                     <LockListDetails lock={lock} />
                 </MyListGroup.Row>
             ))
-            .reverse();
+            .sort((a, b) => {
+                return a.props.children.props.lock.lockedUntil - b.props.children.props.lock.lockedUntil;
+            });
+
+    console.log(listItems);
 
     return (
         <Pblock data-testid="LockListBlock" loading={isLoading} header={props.header}>

--- a/src/containers/lock/components/LockList.jsx
+++ b/src/containers/lock/components/LockList.jsx
@@ -7,9 +7,6 @@ import LockListDetails from "./LockListDetails";
 
 export default function LockList(props) {
     const { isLoading, error, locks } = props.locks;
-
-    console.log(locks);
-
     const listItems =
         locks &&
         locks
@@ -22,8 +19,6 @@ export default function LockList(props) {
             .sort((a, b) => {
                 return a.props.children.props.lock.lockedUntil - b.props.children.props.lock.lockedUntil;
             });
-
-    console.log(listItems);
 
     return (
         <Pblock data-testid="LockListBlock" loading={isLoading} header={props.header}>

--- a/src/containers/lock/lockList/index.js
+++ b/src/containers/lock/lockList/index.js
@@ -14,17 +14,14 @@ function LockList(props) {
     const { location } = props;
     const { isLoading, error, locks } = props.locks;
     const isActivePage = location.pathname === "/lock";
-
     const listItems =
         locks &&
         locks
             .filter(lock => lock.isActive === isActivePage)
-            .map(lock => <LockCard key={`lock-${lock.id}`} lock={lock} />)
             .sort((a, b) => {
-                return isActivePage
-                    ? a.props.lock.lockedUntil - b.props.lock.lockedUntil
-                    : b.props.lock.lockedUntil - a.props.lock.lockedUntil;
-            });
+                return isActivePage ? a.lockedUntil - b.lockedUntil : b.lockedUntil - a.lockedUntil;
+            })
+            .map(lock => <LockCard key={`lock-${lock.id}`} lock={lock} />);
 
     return (
         <Psegment>

--- a/src/containers/lock/lockList/index.js
+++ b/src/containers/lock/lockList/index.js
@@ -18,9 +18,13 @@ function LockList(props) {
     const listItems =
         locks &&
         locks
-            .reverse()
             .filter(lock => lock.isActive === isActivePage)
-            .map(lock => <LockCard key={`lock-${lock.id}`} lock={lock} />);
+            .map(lock => <LockCard key={`lock-${lock.id}`} lock={lock} />)
+            .sort((a, b) => {
+                return isActivePage
+                    ? a.props.lock.lockedUntil - b.props.lock.lockedUntil
+                    : b.props.lock.lockedUntil - a.props.lock.lockedUntil;
+            });
 
     return (
         <Psegment>


### PR DESCRIPTION
#### Nature of the PR: tweak
Sorting of locks/loans by release/due date on My account page and locks/loan pages.

#### Steps to reproduce:
go to augmin.org/loan OR /lock OR /account to see broken sorting of locks & loans
#### Trello card / screenshot / wireframe link:

#### Is connection necessary to test? If so which network?
- [ ] local RPC
- [x] Rinkeby
- [ ] Main Ethereum Network
