### PR TITLE
fix(transfer): fix transfer request validation

### DIFF
--- a/src/components/hash/index.js
+++ b/src/components/hash/index.js
@@ -2,9 +2,9 @@ import React from "react";
 import store from "modules/store";
 
 export default function HashURL(props) {
-    const { hash, children, type, ...other } = props;
+    const { hash, network, children, type, ...other } = props;
     const web3 = store.getState().web3Connect;
-    const url = process.env["REACT_APP_LINK_NETWORK_" + web3.network.id];
+    const url = process.env["REACT_APP_LINK_NETWORK_" + network || web3.network.id];
     const _children = children !== undefined ? children : "View on Etherscan.";
 
     return (

--- a/src/containers/transfer/components/TokenTransferForm.js
+++ b/src/containers/transfer/components/TokenTransferForm.js
@@ -89,7 +89,8 @@ class TokenTransferForm extends React.Component {
                 feeAmount: "0"
             });
 
-            callbackAfterTransfer(values.payee, tokenAmount, res.result.transactionHash);
+            const networkId = store.getState().web3Connect.network.id;
+            callbackAfterTransfer(values.payee, tokenAmount, "AEUR", networkId, res.result.transactionHash);
         }
     }
 

--- a/src/containers/transfer/components/TransferRequest.js
+++ b/src/containers/transfer/components/TransferRequest.js
@@ -12,4 +12,7 @@ export default class TransferRequest extends React.Component {
 
         window.location.replace(link);
     }
+    render() {
+        return "Please, wait... ";
+    }
 }

--- a/src/containers/transfer/components/TransferRequest.js
+++ b/src/containers/transfer/components/TransferRequest.js
@@ -1,18 +1,38 @@
 import React from "react";
+import { withRouter } from "react-router-dom";
+import { Psegment } from "components/PageLayout";
+import { ErrorPanel } from "components/MsgPanels";
 
 import { applyTransferRequestFromUrl, getTransferLink } from "./TransferRequestHelper";
 
-export default class TransferRequest extends React.Component {
+class TransferRequest extends React.Component {
     constructor(props) {
         super(props);
 
-        const urlParams = new URL(document.location).searchParams;
-        const request = applyTransferRequestFromUrl(urlParams);
-        const link = request ? getTransferLink(request) : "/transfer";
+        this.state = { error: null };
 
-        window.location.replace(link);
+        const urlParams = new URL(document.location).searchParams;
+        try {
+            const request = applyTransferRequestFromUrl(urlParams);
+            const link = request ? getTransferLink(request) : "/transfer";
+
+            this.props.history.replace(link);
+        } catch (e) {
+            console.log(e);
+            this.state.error = e;
+        }
     }
     render() {
-        return "Please, wait... ";
+        return (
+            this.state.error && (
+                <Psegment>
+                    <ErrorPanel header="Transfer request error">
+                        <p>{this.state.error.toString()}</p>
+                    </ErrorPanel>
+                </Psegment>
+            )
+        );
     }
 }
+
+export default withRouter(TransferRequest);

--- a/src/containers/transfer/components/TransferRequest.js
+++ b/src/containers/transfer/components/TransferRequest.js
@@ -18,7 +18,6 @@ class TransferRequest extends React.Component {
 
             this.props.history.replace(link);
         } catch (e) {
-            console.log(e);
             this.state.error = e;
         }
     }

--- a/src/containers/transfer/components/TransferRequestAlert.js
+++ b/src/containers/transfer/components/TransferRequestAlert.js
@@ -41,6 +41,7 @@ class TransferRequestAlert extends React.Component {
                                     <HashURL
                                         style={{ color: "inherit" }}
                                         hash={request.beneficiary_address}
+                                        network={request.network_id}
                                         type={"address/"}
                                     >
                                         {request.beneficiary_address}

--- a/src/containers/transfer/components/TransferRequestHelper.js
+++ b/src/containers/transfer/components/TransferRequestHelper.js
@@ -18,7 +18,9 @@ function createUrl(url, params) {
     const qs = new URLSearchParams(origSearch);
 
     for (const key in params) {
-        qs.set(key, params[key]);
+        if (params[key] !== null && params[key] !== "") {
+            qs.set(key, params[key]);
+        }
     }
 
     const search = qs.toString();
@@ -73,7 +75,7 @@ export function applyTransferRequestFromUrl(urlParams) {
             throw new Error("Invalid currency_code parameter. Available values: AEUR");
         }
 
-        transferRequests.push(request);
+        transferRequests.unshift(request);
         transferRequests = transferRequests.filter(
             (value, index, arr) =>
                 arr.findIndex(v => {
@@ -103,17 +105,19 @@ export function callbackAfterTransfer(beneficiary_address, amount, currency_code
         ) {
             deleteTransferRequest(i);
 
-            const link = createUrl(transferRequest.notify_url, {
-                order_id: transferRequest.order_id,
-                token: transferRequest.token,
-                network_id: transferRequest.network_id,
-                beneficiary_address,
-                amount,
-                currency_code: transferRequest.currency_code,
-                tx_hash: transactionHash
-            });
+            if (transferRequest.notify_url) {
+                const link = createUrl(transferRequest.notify_url, {
+                    order_id: transferRequest.order_id,
+                    token: transferRequest.token,
+                    network_id: transferRequest.network_id,
+                    beneficiary_address,
+                    amount,
+                    currency_code: transferRequest.currency_code,
+                    tx_hash: transactionHash
+                });
 
-            window.location.replace(link);
+                window.location.replace(link);
+            }
         }
     }
 }


### PR DESCRIPTION
#### Nature of the PR: bug/tweaks

#### Trello card
https://trello.com/c/OlMPhBsR/245-transfer-request-improvements
- allow query params in notify_url. We append our params if there is any the notify_url (and we override if there is one with the same name)
- transfer/request validations:
  - network_id only 1 (mainnet) or 4 (rinkeby) allowed, default: 1.  Showing invalid param error otherwise.
  - currency_code must be AEUR, default is AEUR. Invalid param error otherwise
- unique request check extended, we check beneficiary_address, amount, network_id and currency_code (eg. if the transfer happens on different network than the requested network_id then there is no callback)
- when displaying beneficiary_address etherscan link points to network which was requested

#### Is connection necessary to test? If so which network?
- [x] local RPC
- [x] Rinkeby
- [X] Main Ethereum Network