### PR TITLE
feat(transfer): transfer request improvements

### DIFF
--- a/src/components/augmint-ui/icon/index.js
+++ b/src/components/augmint-ui/icon/index.js
@@ -10,6 +10,9 @@ export default function Icon(props) {
         case "info":
             className += " fas fa-info";
             break;
+        case "warning":
+            className += " fas fa-exclamation-triangle";
+            break;
         case "check":
             className += " fas fa-check";
             break;

--- a/src/components/hash/index.js
+++ b/src/components/hash/index.js
@@ -4,7 +4,7 @@ import store from "modules/store";
 export default function HashURL(props) {
     const { hash, network, children, type, ...other } = props;
     const web3 = store.getState().web3Connect;
-    const url = process.env["REACT_APP_LINK_NETWORK_" + network || web3.network.id];
+    const url = process.env["REACT_APP_LINK_NETWORK_" + (network || web3.network.id)];
     const _children = children !== undefined ? children : "View on Etherscan.";
 
     return (

--- a/src/containers/PageNotFound.js
+++ b/src/containers/PageNotFound.js
@@ -5,7 +5,7 @@ import { ErrorPanel } from "components/MsgPanels";
 export const PageNotFound = props => {
     return (
         <Psegment>
-            <ErrorPanel header="Page not found">
+            <ErrorPanel header="Page not found" style={{ margin: "1em" }}>
                 <p>Where's {props.location.pathname} ?</p>
                 <p> Not sure.</p>
             </ErrorPanel>

--- a/src/containers/account/components/NoTokenAlert.js
+++ b/src/containers/account/components/NoTokenAlert.js
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import styled from "styled-components";
 import theme from "styles/theme";
 import Message from "components/augmint-ui/message";
+import Icon from "components/augmint-ui/icon";
 
 const dismissedCookie = "noTokenAlertDismissed=true";
 
@@ -50,7 +51,7 @@ class NoTokenAlert extends React.Component {
             balanceIsNull && (
                 <Box onDismiss={this.dismiss} {...this.props}>
                     <Link to="/how-to-get">
-                        <i className="fas fa-exclamation-triangle" style={{ marginRight: 15 }} />
+                        <Icon name="warning" style={{ marginRight: 15 }} />
                         You have no A-EUR yet. <u>How to get?</u> »
                     </Link>
                 </Box>

--- a/src/containers/app/EthereumState.js
+++ b/src/containers/app/EthereumState.js
@@ -14,7 +14,7 @@ import { DiscordButton } from "components/LinkButtons";
 export class EthereumState extends React.Component {
     render() {
         let msg = null;
-        const { web3Connect, contracts, augmintToken, className, children = null } = this.props;
+        const { web3Connect, contracts, augmintToken, extraValidation, className, children = null } = this.props;
         const { network } = web3Connect;
 
         let _className = className + " primaryColor";
@@ -116,6 +116,8 @@ export class EthereumState extends React.Component {
                     <StyledP className={_className}>If you are using Metamask make sure it's unlocked.</StyledP>
                 </WarningPanel>
             );
+        } else if (extraValidation) {
+            msg = extraValidation();
         }
 
         if (msg) {

--- a/src/containers/app/index.js
+++ b/src/containers/app/index.js
@@ -18,7 +18,8 @@ import theme from "styles/theme";
 import AccountHome from "containers/account";
 import HowToGet from "containers/account/HowToGet";
 import TransferPage from "containers/transfer";
-import TransferRequest from "containers/transfer/components/TransferRequest";
+import CreateTransferRequest from "containers/transfer/request/CreateTransferRequest";
+import ShowTransferRequest from "containers/transfer/request/ShowTransferRequest";
 import ExchangeHome from "containers/exchange";
 import LoanMain from "containers/loan";
 import AugmintToken from "containers/augmintToken";
@@ -46,7 +47,7 @@ import LegacyTokens from "./LegacyTokens";
 import LegacyExchanges from "./LegacyExchanges";
 import LegacyLockers from "./LegacyLockers";
 import LegacyLoanManagers from "./LegacyLoanManagers";
-import TransferRequestAlert from "../transfer/components/TransferRequestAlert";
+import TransferRequestAlert from "../transfer/request/TransferRequestAlert";
 
 injectGlobal`
 body {
@@ -220,7 +221,8 @@ class App extends React.Component {
                         <Route exact path="/" component={NotConnectedHome} />
                         <Route exact path="/account" component={AccountHome} />
                         <Route exact path="/transfer" component={TransferPage} />
-                        <Route exact path="/transfer/request" component={TransferRequest} />
+                        <Route exact path="/transfer/request" component={CreateTransferRequest} />
+                        <Route exact path="/transfer/:requestId" component={ShowTransferRequest} />
                         <Route exact path="/exchange" component={ExchangeHome} />
                         <Route exact path="/stability" component={AugmintToken} />
                         <Route exact path="/how-to-get" component={HowToGet} />

--- a/src/containers/transfer/index.js
+++ b/src/containers/transfer/index.js
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import { connectWeb3 } from "modules/web3Provider";
 import augmintTokenProvider from "modules/augmintTokenProvider";
 import TokenTransferForm from "./components/TokenTransferForm";
-import { Pheader, Psegment, Pgrid } from "components/PageLayout";
+import { Pheader, Psegment, Pgrid, Pblock } from "components/PageLayout";
 import { EthereumState } from "containers/app/EthereumState";
 import TopNavTitlePortal from "components/portals/TopNavTitlePortal";
 import NoTokenAlert from "../account/components/NoTokenAlert";
@@ -15,6 +15,8 @@ class TransferPage extends React.Component {
     }
 
     render() {
+        const { augmintToken } = this.props;
+
         return (
             <EthereumState>
                 <Psegment>
@@ -26,7 +28,14 @@ class TransferPage extends React.Component {
                     <Pgrid>
                         <Pgrid.Row>
                             <Pgrid.Column size={{ mobile: 1, tablet: 1 / 2 }}>
-                                <TokenTransferForm />
+                                <Pblock
+                                    loading={
+                                        augmintToken.isLoading || (!augmintToken.isLoaded && !augmintToken.loadError)
+                                    }
+                                    header="Send A-EUR"
+                                >
+                                    <TokenTransferForm />
+                                </Pblock>
                             </Pgrid.Column>
                         </Pgrid.Row>
                     </Pgrid>
@@ -37,6 +46,7 @@ class TransferPage extends React.Component {
 }
 
 const mapStateToProps = state => ({
+    augmintToken: state.augmintToken,
     userAccount: state.userBalances.account
 });
 

--- a/src/containers/transfer/request/CreateTransferRequest.js
+++ b/src/containers/transfer/request/CreateTransferRequest.js
@@ -5,7 +5,7 @@ import { ErrorPanel } from "components/MsgPanels";
 
 import { applyTransferRequestFromUrl, getTransferLink } from "./TransferRequestHelper";
 
-class TransferRequest extends React.Component {
+class CreateTransferRequest extends React.Component {
     constructor(props) {
         super(props);
 
@@ -34,4 +34,4 @@ class TransferRequest extends React.Component {
     }
 }
 
-export default withRouter(TransferRequest);
+export default withRouter(CreateTransferRequest);

--- a/src/containers/transfer/request/ShowTransferRequest.js
+++ b/src/containers/transfer/request/ShowTransferRequest.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { withRouter } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { connectWeb3 } from "modules/web3Provider";
 import augmintTokenProvider from "modules/augmintTokenProvider";
 import { getNetworkName } from "utils/helpers";
@@ -155,7 +155,15 @@ class ShowTransferRequest extends React.Component {
             );
         }
 
-        return <PageNotFound location={this.props.location} />;
+        return (
+            <Psegment>
+                <ErrorPanel header="This transfer doesn't exist or already sent." style={{ margin: "1em" }}>
+                    <p>
+                        <Link to="/">Go to home page »</Link>
+                    </p>
+                </ErrorPanel>
+            </Psegment>
+        );
     }
 }
 
@@ -165,4 +173,4 @@ const mapStateToProps = state => ({
     userAccount: state.userBalances.account
 });
 
-export default withRouter(connect(mapStateToProps)(ShowTransferRequest));
+export default connect(mapStateToProps)(ShowTransferRequest);

--- a/src/containers/transfer/request/ShowTransferRequest.js
+++ b/src/containers/transfer/request/ShowTransferRequest.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import { Link } from "react-router-dom";
+import styled from "styled-components";
 import { connectWeb3 } from "modules/web3Provider";
 import augmintTokenProvider from "modules/augmintTokenProvider";
 import { getNetworkName } from "utils/helpers";
@@ -10,11 +11,23 @@ import { Psegment, Pblock, Pgrid } from "components/PageLayout";
 import { ErrorPanel } from "components/MsgPanels";
 import HashURL from "components/hash";
 import Icon from "components/augmint-ui/icon";
-import { PageNotFound } from "containers/PageNotFound";
 import EthereumState from "containers/app/EthereumState";
 import { Validations } from "components/BaseComponents";
 import TokenTransferForm from "../components/TokenTransferForm";
 import { default as theme, remCalc } from "styles/theme";
+import { media } from "styles/media";
+
+const StyledNetworkInfo = styled.span`
+    display: block;
+    color: ${theme.colors.mediumGrey};
+    font-family: ${theme.typography.fontFamilies.default};
+    font-size: ${remCalc(14)};
+    text-transform: uppercase;
+
+    ${media.tabletMin`
+        float: right;
+    `};
+`;
 
 class ShowTransferRequest extends React.Component {
     constructor(props) {
@@ -76,8 +89,13 @@ class ShowTransferRequest extends React.Component {
                             <Pgrid.Column size={{ mobile: 1 }}>
                                 <Pblock
                                     header={
-                                        "Transfer request" +
-                                        (request.beneficiary_name ? " to " + request.beneficiary_name : "")
+                                        <span>
+                                            Transfer request{" "}
+                                            {request.beneficiary_name ? " to " + request.beneficiary_name : ""}
+                                            <StyledNetworkInfo>
+                                                on {getNetworkName(request.network_id)} network
+                                            </StyledNetworkInfo>
+                                        </span>
                                     }
                                 >
                                     <p>
@@ -92,7 +110,9 @@ class ShowTransferRequest extends React.Component {
                                             {!isNaN(fee) && (
                                                 <small>
                                                     {" "}
-                                                    + {fee} {request.currency_code} fee
+                                                    <span style={{ whiteSpace: "nowrap" }}>
+                                                        + {fee} {request.currency_code} fee
+                                                    </span>
                                                 </small>
                                             )}
                                         </strong>
@@ -112,7 +132,7 @@ class ShowTransferRequest extends React.Component {
                                     <EthereumState extraValidation={getErrors}>
                                         {!augmintToken.isLoading && (
                                             <div>
-                                                <p style={{ color: "grey" }}>
+                                                <p style={{ color: theme.colors.mediumGrey }}>
                                                     <small>
                                                         <Icon name="warning" style={{ marginRight: 5 }} />
                                                         <i>
@@ -125,7 +145,7 @@ class ShowTransferRequest extends React.Component {
                                                     </small>
                                                 </p>
                                                 {request.notify_url && (
-                                                    <p style={{ color: "grey" }}>
+                                                    <p style={{ color: theme.colors.mediumGrey }}>
                                                         <small>
                                                             If transfer was success, we automatically redirect back
                                                             {request.beneficiary_name &&

--- a/src/containers/transfer/request/ShowTransferRequest.js
+++ b/src/containers/transfer/request/ShowTransferRequest.js
@@ -74,7 +74,12 @@ class ShowTransferRequest extends React.Component {
                     <Pgrid>
                         <Pgrid.Row>
                             <Pgrid.Column size={{ mobile: 1 }}>
-                                <Pblock header={`Transfer request to ${request.beneficiary_name}`}>
+                                <Pblock
+                                    header={
+                                        "Transfer request" +
+                                        (request.beneficiary_name ? " to " + request.beneficiary_name : "")
+                                    }
+                                >
                                     <p>
                                         Amount:{" "}
                                         <strong
@@ -102,6 +107,8 @@ class ShowTransferRequest extends React.Component {
                                             {request.beneficiary_address}
                                         </HashURL>
                                     </p>
+
+                                    {request.reference && <p>Reference: {request.reference}</p>}
                                     <EthereumState extraValidation={getErrors}>
                                         {!augmintToken.isLoading && (
                                             <div>
@@ -111,17 +118,19 @@ class ShowTransferRequest extends React.Component {
                                                         <i>
                                                             <b>Warning:</b> you are making a transfer to an address
                                                             provided by an external site. Make sure the address belongs
-                                                            to {request.beneficiary_name} who you are really willing to
-                                                            transfer A-EUR. Funds sent to wrong address might be lost
-                                                            irreversibly.
+                                                            to {request.beneficiary_name}
+                                                            who you are really willing to transfer A-EUR. Funds sent to
+                                                            wrong address might be lost irreversibly.
                                                         </i>
                                                     </small>
                                                 </p>
                                                 {request.notify_url && (
                                                     <p style={{ color: "grey" }}>
                                                         <small>
-                                                            If transfer was success, we automatically redirect back to{" "}
-                                                            {request.beneficiary_name}.
+                                                            If transfer was success, we automatically redirect back
+                                                            {request.beneficiary_name &&
+                                                                ` to ${request.beneficiary_name}`}
+                                                            .
                                                         </small>
                                                     </p>
                                                 )}

--- a/src/containers/transfer/request/ShowTransferRequest.js
+++ b/src/containers/transfer/request/ShowTransferRequest.js
@@ -1,0 +1,159 @@
+import React from "react";
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom";
+import { connectWeb3 } from "modules/web3Provider";
+import augmintTokenProvider from "modules/augmintTokenProvider";
+import { getNetworkName } from "utils/helpers";
+import { getTransferRequest } from "./TransferRequestHelper";
+import { getTransferFee } from "modules/ethereum/transferTransactions";
+import { Psegment, Pblock, Pgrid } from "components/PageLayout";
+import { ErrorPanel } from "components/MsgPanels";
+import HashURL from "components/hash";
+import Icon from "components/augmint-ui/icon";
+import { PageNotFound } from "containers/PageNotFound";
+import EthereumState from "containers/app/EthereumState";
+import { Validations } from "components/BaseComponents";
+import TokenTransferForm from "../components/TokenTransferForm";
+import { default as theme, remCalc } from "styles/theme";
+
+class ShowTransferRequest extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            requestId: this.props.match.params.requestId,
+            request: null
+        };
+    }
+
+    componentDidMount() {
+        connectWeb3();
+        augmintTokenProvider();
+
+        const request = getTransferRequest(this.state.requestId) || null;
+
+        this.setState({
+            request
+        });
+    }
+
+    render() {
+        const { web3Connect, augmintToken } = this.props;
+        const request = this.state.request;
+
+        if (request) {
+            const fee = getTransferFee(request.amount);
+
+            const getErrors = () => {
+                const currentNetworkId = web3Connect.network.id;
+                const isWrongNetwork = currentNetworkId !== request.network_id;
+
+                if (isWrongNetwork) {
+                    const currentNetworkName = getNetworkName(currentNetworkId);
+                    const requestNetworkName = getNetworkName(request.network_id);
+                    return (
+                        <ErrorPanel header="Wrong network">
+                            <p>
+                                The transfer was requested on <strong>{requestNetworkName} network</strong>. You are
+                                currently connected to {currentNetworkName} network.
+                                <br />
+                                Switch manually to {requestNetworkName} network to complete your transfer.
+                            </p>
+                        </ErrorPanel>
+                    );
+                }
+
+                const isNotEnoughToken = Validations.userTokenBalanceWithTransferFee(request.amount);
+                if (!augmintToken.isLoading && isNotEnoughToken) {
+                    return <ErrorPanel header="Insufficient balance">{isNotEnoughToken}</ErrorPanel>;
+                }
+            };
+
+            return (
+                <Psegment>
+                    <Pgrid>
+                        <Pgrid.Row>
+                            <Pgrid.Column size={{ mobile: 1 }}>
+                                <Pblock header={`Transfer request to ${request.beneficiary_name}`}>
+                                    <p>
+                                        Amount:{" "}
+                                        <strong
+                                            style={{
+                                                fontFamily: theme.typography.fontFamilies.currency,
+                                                fontSize: remCalc(24)
+                                            }}
+                                        >
+                                            {request.amount} {request.currency_code}
+                                            {!isNaN(fee) && (
+                                                <small>
+                                                    {" "}
+                                                    + {fee} {request.currency_code} fee
+                                                </small>
+                                            )}
+                                        </strong>
+                                    </p>
+                                    <p>
+                                        Address:{" "}
+                                        <HashURL
+                                            hash={request.beneficiary_address}
+                                            network={request.network_id}
+                                            type={"address/"}
+                                        >
+                                            {request.beneficiary_address}
+                                        </HashURL>
+                                    </p>
+                                    <EthereumState extraValidation={getErrors}>
+                                        {!augmintToken.isLoading && (
+                                            <div>
+                                                <p style={{ color: "grey" }}>
+                                                    <small>
+                                                        <Icon name="warning" style={{ marginRight: 5 }} />
+                                                        <i>
+                                                            <b>Warning:</b> you are making a transfer to an address
+                                                            provided by an external site. Make sure the address belongs
+                                                            to {request.beneficiary_name} who you are really willing to
+                                                            transfer A-EUR. Funds sent to wrong address might be lost
+                                                            irreversibly.
+                                                        </i>
+                                                    </small>
+                                                </p>
+                                                {request.notify_url && (
+                                                    <p style={{ color: "grey" }}>
+                                                        <small>
+                                                            If transfer was success, we automatically redirect back to{" "}
+                                                            {request.beneficiary_name}.
+                                                        </small>
+                                                    </p>
+                                                )}
+                                                <TokenTransferForm
+                                                    isFunctional
+                                                    initialValues={{
+                                                        tokenAmount: request.amount,
+                                                        payee: request.beneficiary_address,
+                                                        narrative: request.reference
+                                                    }}
+                                                    urlResolved
+                                                    submitText="Approve and send"
+                                                />
+                                            </div>
+                                        )}
+                                    </EthereumState>
+                                </Pblock>
+                            </Pgrid.Column>
+                        </Pgrid.Row>
+                    </Pgrid>
+                </Psegment>
+            );
+        }
+
+        return <PageNotFound location={this.props.location} />;
+    }
+}
+
+const mapStateToProps = state => ({
+    web3Connect: state.web3Connect,
+    augmintToken: state.augmintToken,
+    userAccount: state.userBalances.account
+});
+
+export default withRouter(connect(mapStateToProps)(ShowTransferRequest));

--- a/src/containers/transfer/request/TransferRequestAlert.js
+++ b/src/containers/transfer/request/TransferRequestAlert.js
@@ -6,6 +6,8 @@ import { InfoPanel } from "components/MsgPanels";
 import HashURL from "components/hash";
 import Container from "components/augmint-ui/container";
 import { getTransferRequests, getTransferLink, deleteTransferRequest } from "./TransferRequestHelper";
+import { getNetworkName } from "utils/helpers";
+import { default as theme, remCalc } from "styles/theme";
 
 class TransferRequestAlert extends React.Component {
     componentWillMount() {
@@ -33,8 +35,22 @@ class TransferRequestAlert extends React.Component {
                         return (
                             <InfoPanel
                                 header={
-                                    "Transfer request" +
-                                    (request.beneficiary_name ? " to " + request.beneficiary_name : "")
+                                    <span>
+                                        Transfer request{" "}
+                                        {request.beneficiary_name ? " to " + request.beneficiary_name : ""}
+                                        <span
+                                            className="hide-xs"
+                                            style={{
+                                                color: theme.colors.mediumGrey,
+                                                float: "right",
+                                                fontFamily: theme.typography.fontFamilies.default,
+                                                fontSize: remCalc(14),
+                                                textTransform: "uppercase"
+                                            }}
+                                        >
+                                            on {getNetworkName(request.network_id)} network
+                                        </span>
+                                    </span>
                                 }
                                 key={i}
                             >
@@ -43,19 +59,25 @@ class TransferRequestAlert extends React.Component {
                                     <strong>
                                         {request.amount} {request.currency_code}{" "}
                                         {request.beneficiary_name ? " to " + request.beneficiary_name : ""}
-                                    </strong>{" "}
-                                    (
-                                    <HashURL
-                                        style={{ color: "inherit" }}
-                                        hash={request.beneficiary_address}
-                                        network={request.network_id}
-                                        type={"address/"}
-                                    >
-                                        {request.beneficiary_address}
-                                    </HashURL>
-                                    ).
+                                    </strong>
+                                    <span className="hide-xs">
+                                        {" "}
+                                        (address:{" "}
+                                        <HashURL
+                                            style={{ color: "inherit" }}
+                                            hash={request.beneficiary_address}
+                                            network={request.network_id}
+                                            type={"address/"}
+                                        >
+                                            {request.beneficiary_address}
+                                        </HashURL>
+                                        )
+                                    </span>
                                 </p>
-                                <Button to={link}>Complete your transfer</Button>
+                                <Button to={link}>
+                                    <span className="show-xs">Complete</span>
+                                    <span className="hide-xs">Complete your transfer</span>
+                                </Button>
                                 <Button style={{ marginLeft: 20 }} className="ghost" onClick={onDissmiss}>
                                     Dissmiss
                                 </Button>

--- a/src/containers/transfer/request/TransferRequestAlert.js
+++ b/src/containers/transfer/request/TransferRequestAlert.js
@@ -20,7 +20,7 @@ class TransferRequestAlert extends React.Component {
         const transferRequests = getTransferRequests() || [];
         const url = new URL(document.location);
 
-        return transferRequests.length && url.pathname !== "/transfer" ? (
+        return transferRequests.length && url.pathname.indexOf("/transfer/") !== 0 ? (
             <Psegment>
                 <Container>
                     {transferRequests.map((request, i) => {

--- a/src/containers/transfer/request/TransferRequestAlert.js
+++ b/src/containers/transfer/request/TransferRequestAlert.js
@@ -31,11 +31,18 @@ class TransferRequestAlert extends React.Component {
                         };
 
                         return (
-                            <InfoPanel header={`Transfer request to ${request.beneficiary_name}`} key={i}>
+                            <InfoPanel
+                                header={
+                                    "Transfer request" +
+                                    (request.beneficiary_name ? " to " + request.beneficiary_name : "")
+                                }
+                                key={i}
+                            >
                                 <p style={{ marginBottom: 20 }}>
                                     You have a pending transfer request of{" "}
                                     <strong>
-                                        {request.amount} {request.currency_code} to {request.beneficiary_name}
+                                        {request.amount} {request.currency_code}{" "}
+                                        {request.beneficiary_name ? " to " + request.beneficiary_name : ""}
                                     </strong>{" "}
                                     (
                                     <HashURL

--- a/src/modules/ethereum/transferTransactions.js
+++ b/src/modules/ethereum/transferTransactions.js
@@ -69,7 +69,7 @@ export async function transferTokenTx(payload) {
         });
     }
 
-    const transactionHash = await processTx(tx, txName, gasEstimate);
+    const transactionHash = await processTx(tx, txName, gasEstimate, null, payload);
     return { txName, transactionHash };
 }
 

--- a/src/modules/reducers/augmintToken.js
+++ b/src/modules/reducers/augmintToken.js
@@ -141,6 +141,9 @@ async function getAugmintTokenInfo(augmintTokenInstance) {
 }
 
 export function transferToken(payload) {
+    payload.currencyCode = "AEUR";
+    payload.networkId = store.getState().web3Connect.network.id;
+
     return async dispatch => {
         dispatch({
             type: AUGMINT_TOKEN_TRANSFER_REQUESTED,

--- a/src/modules/reducers/submittedTransactions.js
+++ b/src/modules/reducers/submittedTransactions.js
@@ -1,4 +1,5 @@
 import store from "modules/store";
+import { callbackAfterTransfer } from "../../containers/transfer/request/TransferRequestHelper";
 
 export const UPDATE_TX_SUCCESS = "submittedTransactions/UPDATE_TX_SUCCESS";
 export const UPDATE_TX_ERROR = "submittedTransactions/UPDATE_TX_ERROR";
@@ -43,6 +44,10 @@ export const updateTx = tx => {
                 transactions[tx.transactionHash].event === "confirmation"
             ) {
                 transactions[tx.transactionHash].isDismissed = undefined;
+            }
+
+            if (transactions[tx.transactionHash].confirmationNumber >= 5) {
+                callbackAfterTransfer(transactions[tx.transactionHash]);
             }
 
             return dispatch({

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -35,3 +35,14 @@ export const LEGACY_LOANMANAGER_CONTRACTS = {
         "0x214919Abe3f2b7CA7a43a799C4FC7132bBf78e8A" // oldLoanManager2 (oldToken4)
     ]
 };
+
+export const NETWORKS = {
+    1: "Main",
+    2: "Morden",
+    3: "Ropsten",
+    4: "Rinkeby",
+    42: "Kovan",
+    999: "Testrpc",
+    4447: "TruffleLocal",
+    1976: "PrivateChain"
+};

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,3 +1,5 @@
+import { NETWORKS } from "./constants";
+
 export function promiseTimeout(ms, promise) {
     return new Promise(async (resolve, reject) => {
         // create a timeout to reject promise if not resolved
@@ -14,4 +16,26 @@ export function promiseTimeout(ms, promise) {
             reject(err);
         }
     });
+}
+
+export function getNetworkName(networkId) {
+    return NETWORKS[networkId] || `Unknown (id: ${networkId})`;
+}
+
+export function createUrl(url, params) {
+    const i = url.indexOf("?");
+    const origSearch = i >= 0 ? url.slice(i + 1) : "";
+    const origPath = i >= 0 ? url.slice(0, i) : url;
+    const qs = new URLSearchParams(origSearch);
+
+    if (params) {
+        for (const key in params) {
+            if (params[key] !== null && params[key] !== "") {
+                qs.set(key, params[key]);
+            }
+        }
+    }
+
+    const search = qs.toString();
+    return origPath + (search ? "?" + search : "");
 }


### PR DESCRIPTION
#### Nature of the PR: feature
- Transfer request is a separate page now (instead of a prepopulated transfer form)
- Redirect user back to store only after 5 network confirmations
- Fix etherscan links (e.g. in transfer history)
- Validate `beneficiary_address` format on transfer request
- Transfer request page shown even when not connected (with link to how to connect page)
- Don't allow to complete transfer request on other network than it was requested
- Show a warning to user that double check the address on transfer request
- Inform user that they will redirected back to store after successful transfer

#### Steps to reproduce:
Example request url:
/transfer/request?order_id=123&token=abc&network_id=4&beneficiary_address=0xa7ab07ffd413d467541ad3f31bf7102eab465e9b&beneficiary_name=Example%20Store&amount=10.2&currency_code=AEUR&reference=test%20transfer&notify_url=https://hmpg.net/

#### Trello card / screenshot / wireframe link:
https://trello.com/c/OlMPhBsR/245-transfer-request-improvements

#### Is connection necessary to test? If so which network?
- [x] local RPC
- [x] Rinkeby
- [x] Main Ethereum Network