### PR TITLE
fix(topNav, accountInfo): accountInfoPanel close btn @ < tablet

### DIFF
--- a/src/components/accountInfo/styles.js
+++ b/src/components/accountInfo/styles.js
@@ -42,12 +42,13 @@ export const StyledAccountInfo = styled(Pblock)`
         ${media.tablet`
             position: fixed;
             top: 0;
-            left: 0;
+            left: 16px;
             width: 100%;
             height: 100%;
             background: ${theme.colors.secondary};
             opacity: .97;
             padding: 0;
+            z-index: 1;
         `};
     }
 

--- a/src/components/dashboard/containers/topNav/styles.js
+++ b/src/components/dashboard/containers/topNav/styles.js
@@ -216,6 +216,7 @@ export const CloseIcon = styled.img`
             position: fixed;
             top: 15px;
             right: 15px;
+            z-index: 2;
         `};
     }
 `;


### PR DESCRIPTION
#### Nature of the PR: bug/feature/chore
#### Steps to reproduce:
go to augmint.org on mobile/tablet screen size and open the accountInfoPanel from the topNav
#### Trello card / screenshot / wireframe link:

#### Is connection necessary to test? If so which network?
- [ ] local RPC
- [x] Rinkeby
- [x] Main Ethereum Network
