### PR TITLE
don't display Transfer fee when no transfer fee set

### DIFF
--- a/src/containers/augmintToken/index.js
+++ b/src/containers/augmintToken/index.js
@@ -57,6 +57,10 @@ class AugmintToken extends React.Component {
         const ratesIsLoading = this.props.rates.isLoading;
         const ratesLoadError = this.props.rates.loadError;
 
+        const aurSupplyError = metricsError || monetarySupervisorLoadError || augmintTokenError;
+        const ethReservesError = monetarySupervisorLoadError || metricsError;
+        const stabilityRatiosError = ratesLoadError || metricsError || monetarySupervisorLoadError;
+
         if (Object.keys(this.props.metrics.loansData).length) {
             loansCollected = new BigNumber(this.props.metrics.loansData.collectedLoansAmount.toFixed(15))
                 .plus(this.props.metrics.loansData.defaultedLoansAmount)
@@ -106,6 +110,7 @@ class AugmintToken extends React.Component {
                 .plus(this.props.metrics.augmintTokenInfo.feeAccountEthBalance)
                 .toNumber();
         }
+
         let loanLimit = 0;
         const loanProductsList =
             this.props.loanManager &&
@@ -239,7 +244,7 @@ class AugmintToken extends React.Component {
                             style={{ color: "black" }}
                         >
                             {(metricsError || monetarySupervisorLoadError || augmintTokenError) && (
-                                <ErrorPanel header="Error while fetching data">{metricsError.message}</ErrorPanel>
+                                <ErrorPanel header="Error while fetching data">{aurSupplyError.message}</ErrorPanel>
                             )}
                             <StyledHeader as="h3">A-EUR Supply</StyledHeader>
                             <StyledMyListGroup>
@@ -286,8 +291,10 @@ class AugmintToken extends React.Component {
                                             <StyledRow halign="justify" className="borderTop result">
                                                 <StyledCol width={2 / 3}>Total</StyledCol>
                                                 <StyledCol width={1 / 3}>
-                                                    {(this.props.augmintToken.info.totalSupply !== "?"
-                                                        ? Number(this.props.augmintToken.info.totalSupply).toFixed(0)
+                                                    {(this.props.metrics.augmintTokenInfo.totalSupply !== undefined
+                                                        ? Number(
+                                                              this.props.metrics.augmintTokenInfo.totalSupply
+                                                          ).toFixed(0)
                                                         : "?") + " A€"}
                                                 </StyledCol>
                                             </StyledRow>
@@ -303,9 +310,11 @@ class AugmintToken extends React.Component {
                                             <StyledRow halign="justify">
                                                 <StyledCol width={2 / 3}>- A-EUR Market Intervention Reserve</StyledCol>
                                                 <StyledCol width={1 / 3}>
-                                                    {(this.props.monetarySupervisor.info.reserveTokenBalance !== "?"
+                                                    {(this.props.metrics.monetarySupervisorInfo.reserveTokenBalance !==
+                                                    undefined
                                                         ? Number(
-                                                              this.props.monetarySupervisor.info.reserveTokenBalance
+                                                              this.props.metrics.monetarySupervisorInfo
+                                                                  .reserveTokenBalance
                                                           ).toFixed(0)
                                                         : "?") + " A€"}
                                                     <div className="chart-info orange" />
@@ -316,9 +325,10 @@ class AugmintToken extends React.Component {
                                             <StyledRow halign="justify">
                                                 <StyledCol width={2 / 3}>- Fees Reserve</StyledCol>
                                                 <StyledCol width={1 / 3}>
-                                                    {(this.props.augmintToken.info.feeAccountTokenBalance !== "?"
+                                                    {(this.props.metrics.augmintTokenInfo.feeAccountTokenBalance !==
+                                                    undefined
                                                         ? Number(
-                                                              this.props.augmintToken.info.feeAccountTokenBalance
+                                                              this.props.metrics.augmintTokenInfo.feeAccountTokenBalance
                                                           ).toFixed(0)
                                                         : "?") + " A€"}
                                                     <div className="chart-info orange" />
@@ -329,10 +339,10 @@ class AugmintToken extends React.Component {
                                             <StyledRow halign="justify">
                                                 <StyledCol width={2 / 3}>- Earned Interest Reserve</StyledCol>
                                                 <StyledCol width={1 / 3}>
-                                                    {(this.props.monetarySupervisor.info
-                                                        .interestEarnedAccountTokenBalance !== "?"
+                                                    {(this.props.metrics.monetarySupervisorInfo
+                                                        .interestEarnedAccountTokenBalance !== undefined
                                                         ? Number(
-                                                              this.props.monetarySupervisor.info
+                                                              this.props.metrics.monetarySupervisorInfo
                                                                   .interestEarnedAccountTokenBalance
                                                           ).toFixed(0)
                                                         : "?") + " A€"}
@@ -382,12 +392,9 @@ class AugmintToken extends React.Component {
                                 </StyledRow>
                             </StyledMyListGroup>
                         </Segment>
-                        <Segment
-                            loading={monetarySupervisorIsLoading || augmintTokenIsLoading}
-                            style={{ color: "black" }}
-                        >
-                            {(monetarySupervisorLoadError || augmintTokenError) && (
-                                <ErrorPanel header="Error while fetching data">{metricsError.message}</ErrorPanel>
+                        <Segment loading={monetarySupervisorIsLoading || metricsIsLoading} style={{ color: "black" }}>
+                            {(monetarySupervisorLoadError || metricsError) && (
+                                <ErrorPanel header="Error while fetching data">{ethReservesError.message}</ErrorPanel>
                             )}
                             <StyledHeader as="h3">ETH Reserves</StyledHeader>
                             <StyledMyListGroup>
@@ -397,9 +404,11 @@ class AugmintToken extends React.Component {
                                             <StyledRow halign="justify">
                                                 <StyledCol width={2 / 3}>ETH Market Intervention Reserve</StyledCol>
                                                 <StyledCol width={1 / 3}>
-                                                    {(this.props.monetarySupervisor.info.reserveEthBalance !== "?"
+                                                    {(this.props.metrics.monetarySupervisorInfo.reserveEthBalance !==
+                                                    undefined
                                                         ? Number(
-                                                              this.props.monetarySupervisor.info.reserveEthBalance
+                                                              this.props.metrics.monetarySupervisorInfo
+                                                                  .reserveEthBalance
                                                           ).toFixed(4)
                                                         : "?") + " ETH"}
                                                 </StyledCol>
@@ -409,9 +418,10 @@ class AugmintToken extends React.Component {
                                             <StyledRow halign="justify">
                                                 <StyledCol width={2 / 3}>ETH Fees</StyledCol>
                                                 <StyledCol width={1 / 3}>
-                                                    {(this.props.augmintToken.info.feeAccountEthBalance !== "?"
+                                                    {(this.props.metrics.augmintTokenInfo.feeAccountEthBalance !==
+                                                    undefined
                                                         ? Number(
-                                                              this.props.augmintToken.info.feeAccountEthBalance
+                                                              this.props.metrics.augmintTokenInfo.feeAccountEthBalance
                                                           ).toFixed(4)
                                                         : "?") + " ETH"}
                                                 </StyledCol>
@@ -436,7 +446,9 @@ class AugmintToken extends React.Component {
                             style={{ color: "black" }}
                         >
                             {(ratesLoadError || metricsError || monetarySupervisorLoadError) && (
-                                <ErrorPanel header="Error while fetching data">{metricsError.message}</ErrorPanel>
+                                <ErrorPanel header="Error while fetching data">
+                                    {stabilityRatiosError.message}
+                                </ErrorPanel>
                             )}
                             <StyledHeader as="h3">Stability Ratios</StyledHeader>
                             <StyledMyListGroup>
@@ -448,7 +460,7 @@ class AugmintToken extends React.Component {
                                                 <StyledCol width={1 / 3}>
                                                     {(loanCollateralCoverageRatio !== "?"
                                                         ? loanCollateralCoverageRatio
-                                                        : "?") + "%"}
+                                                        : "? ") + "%"}
                                                 </StyledCol>
                                             </StyledRow>
                                         </MyListGroup>
@@ -496,7 +508,7 @@ class AugmintToken extends React.Component {
                                                               (this.props.monetarySupervisor.info.ltdPercent * 10000) /
                                                               100
                                                           ).toFixed(2)
-                                                        : "?") + "%"}
+                                                        : "? ") + "%"}
                                                 </StyledCol>
                                             </StyledRow>
                                         </MyListGroup>

--- a/src/containers/augmintToken/index.js
+++ b/src/containers/augmintToken/index.js
@@ -20,7 +20,7 @@ import Button from "components/augmint-ui/button";
 
 import { StyledContainer, StyledHeader, StyledMyListGroup, StyledRow, StyledCol } from "./styles";
 import theme from "styles/theme";
-import { theme as medeaTheme } from "styles/media";
+import { theme as mediaTheme } from "styles/media";
 import { ThemeProvider } from "styled-components";
 
 class AugmintToken extends React.Component {
@@ -234,7 +234,7 @@ class AugmintToken extends React.Component {
 
         return (
             <EthereumState>
-                <ThemeProvider theme={medeaTheme}>
+                <ThemeProvider theme={mediaTheme}>
                     <StyledContainer>
                         <TopNavTitlePortal>
                             <Pheader header="Stability Dashboard" />

--- a/src/containers/augmintToken/index.js
+++ b/src/containers/augmintToken/index.js
@@ -241,7 +241,7 @@ class AugmintToken extends React.Component {
                             {(metricsError || monetarySupervisorLoadError || augmintTokenError) && (
                                 <ErrorPanel header="Error while fetching data">{metricsError.message}</ErrorPanel>
                             )}
-                            <StyledHeader as="h3" content="A-EUR Supply" />
+                            <StyledHeader as="h3">A-EUR Supply</StyledHeader>
                             <StyledMyListGroup>
                                 <StyledRow wrap={true} valign="stretch">
                                     <StyledCol width={{ tablet: 1, desktop: 3 / 5, giant: 2 / 5 }}>
@@ -389,7 +389,7 @@ class AugmintToken extends React.Component {
                             {(monetarySupervisorLoadError || augmintTokenError) && (
                                 <ErrorPanel header="Error while fetching data">{metricsError.message}</ErrorPanel>
                             )}
-                            <StyledHeader as="h3" content="ETH Reserves" />
+                            <StyledHeader as="h3">ETH Reserves</StyledHeader>
                             <StyledMyListGroup>
                                 <StyledRow>
                                     <StyledCol width={{ tablet: 1, desktop: 3 / 5, giant: 2 / 5 }}>
@@ -438,7 +438,7 @@ class AugmintToken extends React.Component {
                             {(ratesLoadError || metricsError || monetarySupervisorLoadError) && (
                                 <ErrorPanel header="Error while fetching data">{metricsError.message}</ErrorPanel>
                             )}
-                            <StyledHeader as="h3" content="Stability Ratios" />
+                            <StyledHeader as="h3">Stability Ratios</StyledHeader>
                             <StyledMyListGroup>
                                 <StyledRow>
                                     <StyledCol width={{ tablet: 1, desktop: 3 / 5, giant: 2 / 5 }}>
@@ -532,74 +532,89 @@ class AugmintToken extends React.Component {
                                 </StyledRow>
                             </StyledMyListGroup>
                         </Segment>
-                        <StyledHeader as="h3" content="Loan & Lock Conditions" />
-                        <StyledMyListGroup>
-                            <StyledRow>
-                                <StyledCol width={{ tablet: 1, desktop: 3 / 5, giant: 2 / 5 }}>
-                                    <MyListGroup>
-                                        <StyledRow halign="justify" valign="stretch" wrap={true}>
-                                            <StyledCol
-                                                width={{ tablet: 1, desktop: 1 / 2 }}
-                                                style={{ padding: "0 15px", marginTop: 15 }}
-                                            >
-                                                <MyListGroup>
-                                                    <StyledRow halign="justify" className="result">
-                                                        <StyledCol className="center">Loans</StyledCol>
-                                                    </StyledRow>
-                                                    <StyledRow halign="justify">
-                                                        <StyledCol width={3 / 5}>Loan Limit</StyledCol>
-                                                        <StyledCol width={2 / 5}>{loanLimit + " A€"}</StyledCol>
-                                                    </StyledRow>
-                                                    <br />
-                                                    <StyledRow halign="justify" className="result smaller">
-                                                        <StyledCol width={1 / 2}>Term</StyledCol>
-                                                        <StyledCol width={1 / 2}>pa. Interest</StyledCol>
-                                                    </StyledRow>
-                                                    {loanProductsList}
-                                                </MyListGroup>
-                                            </StyledCol>
-                                            <StyledCol
-                                                width={{ tablet: 1, desktop: 1 / 2 }}
-                                                style={{ padding: "0 15px", marginTop: 15 }}
-                                            >
-                                                <MyListGroup>
-                                                    <StyledRow halign="justify" className="result">
-                                                        <StyledCol className="center">Lock-ins</StyledCol>
-                                                    </StyledRow>
-                                                    <StyledRow halign="justify">
-                                                        <StyledCol width={3 / 5} className="alignLeft">
-                                                            Lock-in Limit
-                                                        </StyledCol>
-                                                        <StyledCol width={2 / 5}>{lockLimit + " A€"}</StyledCol>
-                                                    </StyledRow>
-                                                    <br />
-                                                    <StyledRow halign="justify" className="result smaller">
-                                                        <StyledCol width={1 / 2} className="alignLeft">
-                                                            Term
-                                                        </StyledCol>
-                                                        <StyledCol width={1 / 2}>pa. Interest</StyledCol>
-                                                    </StyledRow>
-                                                    {lockProductsList}
-                                                </MyListGroup>
-                                            </StyledCol>
-                                        </StyledRow>
-                                        <StyledRow>
-                                            <StyledCol>
-                                                <Button
-                                                    content="Loans to Collect"
-                                                    data-testid="loansToCollectButton"
-                                                    to="/loan/collect"
-                                                    icon="angle-right"
-                                                    labelposition="right"
-                                                    size="large"
-                                                    style={{ marginBottom: "15px" }}
-                                                />
-                                            </StyledCol>
-                                        </StyledRow>
-                                    </MyListGroup>
-                                </StyledCol>
-                            </StyledRow>
-                        </StyledMyListGroup>
+                        <Segment>
+                            <StyledHeader as="h3">Loan & Lock Conditions</StyledHeader>
+                            <StyledMyListGroup>
+                                <StyledRow>
+                                    <StyledCol
+                                        width={{ tablet: 1, desktop: 3 / 5, giant: 2 / 5 }}
+                                        style={{ padding: "0 0 .5em" }}
+                                    >
+                                        <MyListGroup>
+                                            <StyledRow halign="justify" valign="stretch" wrap={true}>
+                                                <StyledCol
+                                                    width={{ tablet: 1, desktop: 1 / 2 }}
+                                                    style={{ padding: "0 15px", marginTop: 15 }}
+                                                >
+                                                    <MyListGroup>
+                                                        <StyledRow halign="justify" className="result">
+                                                            <StyledCol
+                                                                className="center"
+                                                                style={{ padding: "0 0 .5em" }}
+                                                            >
+                                                                Loans
+                                                            </StyledCol>
+                                                        </StyledRow>
+                                                        <StyledRow halign="justify">
+                                                            <StyledCol width={3 / 5}>Loan Limit</StyledCol>
+                                                            <StyledCol width={2 / 5}>{loanLimit + " A€"}</StyledCol>
+                                                        </StyledRow>
+                                                        <br />
+                                                        <StyledRow halign="justify" className="result smaller">
+                                                            <StyledCol width={1 / 2}>Term</StyledCol>
+                                                            <StyledCol width={1 / 2}>pa. Interest</StyledCol>
+                                                        </StyledRow>
+                                                        {loanProductsList}
+                                                    </MyListGroup>
+                                                </StyledCol>
+                                                <StyledCol
+                                                    width={{ tablet: 1, desktop: 1 / 2 }}
+                                                    style={{ padding: "0 15px", marginTop: 15 }}
+                                                >
+                                                    <MyListGroup>
+                                                        <StyledRow halign="justify" className="result">
+                                                            <StyledCol
+                                                                className="center"
+                                                                style={{ padding: "0 0 .5em" }}
+                                                            >
+                                                                Lock-ins
+                                                            </StyledCol>
+                                                        </StyledRow>
+                                                        <StyledRow halign="justify">
+                                                            <StyledCol width={3 / 5} className="alignLeft">
+                                                                Lock-in Limit
+                                                            </StyledCol>
+                                                            <StyledCol width={2 / 5}>{lockLimit + " A€"}</StyledCol>
+                                                        </StyledRow>
+                                                        <br />
+                                                        <StyledRow halign="justify" className="result smaller">
+                                                            <StyledCol width={1 / 2} className="alignLeft">
+                                                                Term
+                                                            </StyledCol>
+                                                            <StyledCol width={1 / 2}>pa. Interest</StyledCol>
+                                                        </StyledRow>
+                                                        {lockProductsList}
+                                                    </MyListGroup>
+                                                </StyledCol>
+                                            </StyledRow>
+                                            <StyledRow>
+                                                <StyledCol>
+                                                    <Button
+                                                        content="Loans to Collect"
+                                                        data-testid="loansToCollectButton"
+                                                        to="/loan/collect"
+                                                        icon="angle-right"
+                                                        labelposition="right"
+                                                        size="large"
+                                                        style={{ marginBottom: "15px" }}
+                                                    />
+                                                </StyledCol>
+                                            </StyledRow>
+                                        </MyListGroup>
+                                    </StyledCol>
+                                </StyledRow>
+                            </StyledMyListGroup>
+                        </Segment>
                     </StyledContainer>
                 </ThemeProvider>
             </EthereumState>

--- a/src/containers/augmintToken/styles.js
+++ b/src/containers/augmintToken/styles.js
@@ -26,6 +26,7 @@ export const StyledContainer = styled.div`
 
 export const StyledHeader = styled(Header)`
     ${baseStyle};
+    font-family: ${theme.typography.fontFamilies.title};
     margin: 25px 10px 10px;
     background-color: ${theme.colors.opacExtraLighterGrey};
     line-height: ${remCalc(45)};

--- a/src/containers/augmintToken/styles.js
+++ b/src/containers/augmintToken/styles.js
@@ -26,7 +26,7 @@ export const StyledContainer = styled.div`
 
 export const StyledHeader = styled(Header)`
     ${baseStyle};
-    margin: 25px 10px;
+    margin: 25px 10px 10px;
     background-color: ${theme.colors.opacExtraLighterGrey};
     line-height: ${remCalc(45)};
     padding-left: ${remCalc(35)};

--- a/src/containers/transfer/components/TokenTransferForm.js
+++ b/src/containers/transfer/components/TokenTransferForm.js
@@ -155,14 +155,14 @@ class TokenTransferForm extends React.Component {
                                     style={{ borderRadius: theme.borderRadius.left }}
                                     labelAlignRight="A-EUR"
                                 />
-                                {augmintToken.info.feeMax !== 0 &&
-                                    augmintToken.info.feeMin !== 0 &&
-                                    augmintToken.info.feePt !== 0 && (
-                                        <small style={{ display: "block", marginBottom: 10 }}>
-                                            Fee: <span data-testid="transferFeeAmount">{this.state.feeAmount}</span> A€{" "}
-                                            <TransferFeeToolTip augmintTokenInfo={augmintToken.info} />
-                                        </small>
-                                    )}
+                                {(augmintToken.info.feeMax !== 0 ||
+                                    augmintToken.info.feeMin !== 0 ||
+                                    augmintToken.info.feePt !== 0) && (
+                                    <small style={{ display: "block", marginBottom: 10 }}>
+                                        Fee: <span data-testid="transferFeeAmount">{this.state.feeAmount}</span> A€{" "}
+                                        <TransferFeeToolTip augmintTokenInfo={augmintToken.info} />
+                                    </small>
+                                )}
 
                                 <Field
                                     component={Form.Field}

--- a/src/containers/transfer/components/TokenTransferForm.js
+++ b/src/containers/transfer/components/TokenTransferForm.js
@@ -155,10 +155,14 @@ class TokenTransferForm extends React.Component {
                                     style={{ borderRadius: theme.borderRadius.left }}
                                     labelAlignRight="A-EUR"
                                 />
-                                <small style={{ display: "block", marginBottom: 10 }}>
-                                    Fee: <span data-testid="transferFeeAmount">{this.state.feeAmount}</span> A€{" "}
-                                    <TransferFeeToolTip augmintTokenInfo={augmintToken.info} />
-                                </small>
+                                {augmintToken.info.feeMax !== 0 &&
+                                    augmintToken.info.feeMin !== 0 &&
+                                    augmintToken.info.feePt !== 0 && (
+                                        <small style={{ display: "block", marginBottom: 10 }}>
+                                            Fee: <span data-testid="transferFeeAmount">{this.state.feeAmount}</span> A€{" "}
+                                            <TransferFeeToolTip augmintTokenInfo={augmintToken.info} />
+                                        </small>
+                                    )}
 
                                 <Field
                                     component={Form.Field}

--- a/src/modules/ethereum/metricsTransaction.js
+++ b/src/modules/ethereum/metricsTransaction.js
@@ -12,7 +12,10 @@ import {
     LEGACY_INTEREST_EARNED_CONTRACTS
 } from "utils/constants";
 
-function sum(arr) {
+function sum(arr, funcName) {
+    console.log(funcName);
+    console.log(arr);
+    arr.forEach(item => console.log(item, typeof item));
     return arr.reduce((res, item) => res.plus(item), new BigNumber(0));
 }
 
@@ -51,18 +54,27 @@ export async function fetchAllTokensInfo() {
     const latestToken = store.getState().augmintToken;
 
     return {
-        totalSupply: sum([
-            latestToken.info.totalSupply,
-            ...(await Promise.all(LEGACY_AEUR_CONTRACTS[web3.network.id].map(fetchTokenInfo)))
-        ]),
-        feeAccountTokenBalance: sum([
-            latestToken.info.feeAccountTokenBalance,
-            ...(await Promise.all(LEGACY_FEE_CONTRACTS[web3.network.id].map(fetchTokenBalance)))
-        ]),
-        feeAccountEthBalance: sum([
-            latestToken.info.feeAccountEthBalance,
-            ...(await Promise.all(LEGACY_FEE_CONTRACTS[web3.network.id].map(fetchEthBalance)))
-        ])
+        totalSupply: sum(
+            [
+                latestToken.info.totalSupply,
+                ...(await Promise.all(LEGACY_AEUR_CONTRACTS[web3.network.id].map(fetchTokenInfo)))
+            ],
+            "totalSupply:"
+        ),
+        feeAccountTokenBalance: sum(
+            [
+                latestToken.info.feeAccountTokenBalance,
+                ...(await Promise.all(LEGACY_FEE_CONTRACTS[web3.network.id].map(fetchTokenBalance)))
+            ],
+            "feeAccountTokenBalance:"
+        ),
+        feeAccountEthBalance: sum(
+            [
+                latestToken.info.feeAccountEthBalance,
+                ...(await Promise.all(LEGACY_FEE_CONTRACTS[web3.network.id].map(fetchEthBalance)))
+            ],
+            "feeAccountEthBalance:"
+        )
     };
 }
 
@@ -83,24 +95,36 @@ export async function fetchAllMonetarySupervisorInfo() {
     const latestMs = store.getState().monetarySupervisor;
 
     return {
-        issuedByStabilityBoard: sum([
-            latestMs.info.issuedByStabilityBoard,
-            ...(await Promise.all(
-                LEGACY_MONETARY_SUPERVISOR_CONTRACTS[web3.network.id].map(fetchMonetarySupervisorInfo)
-            ))
-        ]),
-        reserveTokenBalance: sum([
-            latestMs.info.reserveTokenBalance,
-            ...(await Promise.all(LEGACY_RESERVES_CONTRACTS[web3.network.id].map(fetchTokenBalance)))
-        ]),
-        reserveEthBalance: sum([
-            latestMs.info.reserveEthBalance,
-            ...(await Promise.all(LEGACY_RESERVES_CONTRACTS[web3.network.id].map(fetchEthBalance)))
-        ]),
-        interestEarnedAccountTokenBalance: sum([
-            latestMs.info.interestEarnedAccountTokenBalance,
-            ...(await Promise.all(LEGACY_INTEREST_EARNED_CONTRACTS[web3.network.id].map(fetchTokenBalance)))
-        ])
+        issuedByStabilityBoard: sum(
+            [
+                latestMs.info.issuedByStabilityBoard,
+                ...(await Promise.all(
+                    LEGACY_MONETARY_SUPERVISOR_CONTRACTS[web3.network.id].map(fetchMonetarySupervisorInfo)
+                ))
+            ],
+            "issuedByStabilityBoard:"
+        ),
+        reserveTokenBalance: sum(
+            [
+                latestMs.info.reserveTokenBalance,
+                ...(await Promise.all(LEGACY_RESERVES_CONTRACTS[web3.network.id].map(fetchTokenBalance)))
+            ],
+            "reserveTokenBalance:"
+        ),
+        reserveEthBalance: sum(
+            [
+                latestMs.info.reserveEthBalance,
+                ...(await Promise.all(LEGACY_RESERVES_CONTRACTS[web3.network.id].map(fetchEthBalance)))
+            ],
+            "reserveEthBalance:"
+        ),
+        interestEarnedAccountTokenBalance: sum(
+            [
+                latestMs.info.interestEarnedAccountTokenBalance,
+                ...(await Promise.all(LEGACY_INTEREST_EARNED_CONTRACTS[web3.network.id].map(fetchTokenBalance)))
+            ],
+            "interestEarnedAccountTokenBalance:"
+        )
     };
 }
 

--- a/src/modules/ethereum/metricsTransaction.js
+++ b/src/modules/ethereum/metricsTransaction.js
@@ -13,9 +13,6 @@ import {
 } from "utils/constants";
 
 function sum(arr, funcName) {
-    console.log(funcName);
-    console.log(arr);
-    arr.forEach(item => console.log(item, typeof item));
     return arr.reduce((res, item) => res.plus(item), new BigNumber(0));
 }
 

--- a/src/modules/reducers/monetarySupervisor.js
+++ b/src/modules/reducers/monetarySupervisor.js
@@ -139,7 +139,7 @@ async function getMonetarySupervisorInfo(monetarySupervisorInstance) {
         augmintTokenInstance.methods.balanceOf(interestEarnedAccountAddress).call()
     ]);
 
-    const reserveEthBalance = bn_reserveWeiBalance / ONE_ETH_IN_WEI;
+    const reserveEthBalance = (bn_reserveWeiBalance / ONE_ETH_IN_WEI).toString();
     const reserveTokenBalance = bn_reserveTokenBalance / DECIMALS_DIV;
     const interestEarnedAccountTokenBalance = bn_interestEarnedAccountTokenBalance / DECIMALS_DIV;
 


### PR DESCRIPTION
#### Nature of the PR: feature
#### Steps to reproduce:
on the netlify link go to /transfer on both the main & rinkeby network and check out the fee under the amount field.

#### Trello card / screenshot:
https://trello.com/c/3nOFeBq2

![image](https://user-images.githubusercontent.com/32713470/51551766-74b91300-1e6f-11e9-8c42-2d9362173558.png)

#### Is connection necessary to test? If so which network?
- [ ] local RPC
- [x] Rinkeby
- [x] Main Ethereum Network
