### PR TITLE
Travis to use latest yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
 before_install:
   - export BRANCH="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
   - sudo apt-get install -y libgconf-2-4 # https://github.com/cypress-io/cypress/issues/1526
-  - yarn add wait-on # https://docs.cypress.io/guides/guides/continuous-integration.html#Challenges
   - yarn global add greenkeeper-lockfile
 install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
   directories:
     - "~/.cache"  # based on: https://docs.cypress.io/guides/guides/continuous-integration.html#Travis
 before_install:
-    - export PATH=$PATH:`yarn global bin` # workaround for "greenkeeper-lockfile-update: command not found" caused by a regression of this travis issue: https://github.com/travis-ci/travis-ci/issues/8870#issuecomment-351395853
+    - curl -o- -L https://yarnpkg.com/install.sh | bash
     - export BRANCH="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
     - yarn global add greenkeeper-lockfile
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
     - "~/.cache" # based on: https://docs.cypress.io/guides/guides/continuous-integration.html#Travis
 before_install:
   - export BRANCH="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
+  - apt-get install libgconf-2-4 # https://github.com/cypress-io/cypress/issues/1526
   - yarn global add greenkeeper-lockfile
 install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   - export BRANCH="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
 install:
   - sudo apt-get install -y libgconf-2-4 # https://github.com/cypress-io/cypress/issues/1526
-  - dpkg -L libgconf-2-4
   - yarn global add greenkeeper-lockfile
   - |
     if [[ $BRANCH == "greenkeeper/"* ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ cache:
     - "~/.cache" # based on: https://docs.cypress.io/guides/guides/continuous-integration.html#Travis
 before_install:
   - export BRANCH="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
-  - sudo apt-get install -y libgconf-2-4 # https://github.com/cypress-io/cypress/issues/1526
-  - yarn global add greenkeeper-lockfile
 install:
+  - sudo apt-get install -y libgconf-2-4 # https://github.com/cypress-io/cypress/issues/1526
+  - dpkg -L libgconf-2-4
+  - yarn global add greenkeeper-lockfile
   - |
     if [[ $BRANCH == "greenkeeper/"* ]]; then
       echo Greenkeeper build using .yarnrc.greenkeeper; cp .yarnrc.greenkeeper .yarnrc; yarn install;

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - greenkeeper-lockfile-update
   - yarn ganache:run > ganache.out &
   - yarn contracts:migrate --reset # Migrations.sol might be deployed to different address than address in checked in json-s
-  - yarn start & wait-on http://localhost:3000
+  - yarn start & wait-on http-get://localhost:3000
 script:
   - yarn cypress:runrecord
 # discord webhooks hack until this is released: https://github.com/travis-ci/travis-tasks/pull/71

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,26 @@
 language: node_js
 cache:
   directories:
-    - "~/.cache"  # based on: https://docs.cypress.io/guides/guides/continuous-integration.html#Travis
+    - "~/.cache" # based on: https://docs.cypress.io/guides/guides/continuous-integration.html#Travis
 before_install:
-    - curl -o- -L https://yarnpkg.com/install.sh | bash
-    - export BRANCH="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
-    - yarn global add greenkeeper-lockfile
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export BRANCH="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
+  - yarn global add greenkeeper-lockfile
 install:
-    - |
-      if [[ $BRANCH == "greenkeeper/"* ]]; then
-        echo Greenkeeper build using .yarnrc.greenkeeper; cp .yarnrc.greenkeeper .yarnrc; yarn install;
-      else
-        echo Normal build using .yarnrc and --frozen-lockfile option; yarn install --frozen-lockfile;
-      fi
-    - cd augmint-contracts && yarn install && cd ..
+  - |
+    if [[ $BRANCH == "greenkeeper/"* ]]; then
+      echo Greenkeeper build using .yarnrc.greenkeeper; cp .yarnrc.greenkeeper .yarnrc; yarn install;
+    else
+      echo Normal build using .yarnrc and --frozen-lockfile option; yarn install --frozen-lockfile;
+    fi
+  - cd augmint-contracts && yarn install && cd ..
 before_script:
-    - greenkeeper-lockfile-update
-    - yarn ganache:run > ganache.out &
-    - yarn contracts:migrate --reset # Migrations.sol might be deployed to different address than address in checked in json-s
-    - yarn start  &
+  - greenkeeper-lockfile-update
+  - yarn ganache:run > ganache.out &
+  - yarn contracts:migrate --reset # Migrations.sol might be deployed to different address than address in checked in json-s
+  - yarn start  &
 script:
-    - yarn cypress:runrecord
+  - yarn cypress:runrecord
 # discord webhooks hack until this is released: https://github.com/travis-ci/travis-tasks/pull/71
 after_script: greenkeeper-lockfile-upload
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
+dist: xenial # https://docs.travis-ci.com/user/reference/xenial/
 language: node_js
 cache:
   directories:
     - "~/.cache" # based on: https://docs.cypress.io/guides/guides/continuous-integration.html#Travis
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
-  - export PATH="$HOME/.yarn/bin:$PATH"
   - export BRANCH="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
   - yarn global add greenkeeper-lockfile
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 before_install:
   - export BRANCH="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
   - sudo apt-get install -y libgconf-2-4 # https://github.com/cypress-io/cypress/issues/1526
+  - yarn add wait-on # https://docs.cypress.io/guides/guides/continuous-integration.html#Challenges
   - yarn global add greenkeeper-lockfile
 install:
   - |
@@ -19,7 +20,7 @@ before_script:
   - greenkeeper-lockfile-update
   - yarn ganache:run > ganache.out &
   - yarn contracts:migrate --reset # Migrations.sol might be deployed to different address than address in checked in json-s
-  - yarn start  &
+  - yarn start & wait-on http://localhost:3000
 script:
   - yarn cypress:runrecord
 # discord webhooks hack until this is released: https://github.com/travis-ci/travis-tasks/pull/71

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
     - "~/.cache" # based on: https://docs.cypress.io/guides/guides/continuous-integration.html#Travis
 before_install:
   - export BRANCH="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
-  - apt-get install libgconf-2-4 # https://github.com/cypress-io/cypress/issues/1526
+  - sudo apt-get install -y libgconf-2-4 # https://github.com/cypress-io/cypress/issues/1526
   - yarn global add greenkeeper-lockfile
 install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache:
     - "~/.cache" # based on: https://docs.cypress.io/guides/guides/continuous-integration.html#Travis
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH="$HOME/.yarn/bin:$PATH"
   - export BRANCH="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
   - yarn global add greenkeeper-lockfile
 install:

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -9,7 +9,7 @@ before(function() {
     cy.ganacheTakeSnapshot();
     cy.issueTo(100000); // to make tests independent. issue to accounts[0] by default (amount with token decimals)
 
-    cy.visit("/");
+    cy.visit("/", { timeout: 60000 }); // extra time for webserver ramp up in CI env
     cy.get("[data-testid=useAEurButton]").click();
     cy.get("[data-testid=TryItConnectedPanel]").should("contain", "You are connected");
     cy.get("[data-testid=disclaimerCloseButton").click();

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -9,7 +9,7 @@ before(function() {
     cy.ganacheTakeSnapshot();
     cy.issueTo(100000); // to make tests independent. issue to accounts[0] by default (amount with token decimals)
 
-    cy.visit("/", { timeout: 60000 }); // extra time for webserver ramp up in CI env
+    cy.visit("/");
     cy.get("[data-testid=useAEurButton]").click();
     cy.get("[data-testid=TryItConnectedPanel]").should("contain", "You are connected");
     cy.get("[data-testid=disclaimerCloseButton").click();

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "ethereumjs-util": "6.1.0",
     "ethers": "4.0.26",
     "moment": "2.22.2",
-    "react": "16.8.3",
     "parse": "2.2.1",
+    "react": "16.8.3",
     "react-copy-to-clipboard": "5.0.1",
     "react-dom": "16.8.3",
     "react-ga": "2.5.6",
@@ -28,8 +28,8 @@
     "redux-thunk": "2.3.0",
     "redux-watch": "1.1.1",
     "stringifier": "2.0.0",
-    "styled-components-grid": "2.2.1",
     "styled-components": "4.1.3",
+    "styled-components-grid": "2.2.1",
     "styled-tools": "1.7.0",
     "web3": "1.0.0-beta.33"
   },
@@ -47,10 +47,11 @@
   },
   "devDependencies": {
     "cypress": "3.1.4",
-    "husky": "1.3.1",
     "eslint-plugin-cypress": "2.2.1",
+    "husky": "1.3.1",
     "prettier": "1.15.3",
-    "pretty-quick": "1.9.0"
+    "pretty-quick": "1.9.0",
+    "wait-on": "3.2.0"
   },
   "greenkeeper": {
     "ignore": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1369,9 +1369,9 @@ ajv@^5.1.0:
     json-schema-traverse "^0.3.0"
 
 ajv@^6.1.0, ajv@^6.5.3, ajv@^6.5.5, ajv@^6.9.1:
-  version "6.9.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.2.tgz#4927adb83e7f48e5a32b45729744c71ec39c9c7b"
-  integrity sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
@@ -1384,9 +1384,9 @@ alphanum-sort@^1.0.0:
   integrity sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=
 
 ansi-colors@^3.0.0:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
-  integrity sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
+  integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
 ansi-escapes@^1.0.0:
   version "1.4.0"
@@ -2403,9 +2403,9 @@ camelcase@^4.1.0:
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
 camelcase@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
-  integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.1.0.tgz#29e83b9cfaf7ad478f401a187ae089cf83c257ea"
+  integrity sha512-WP9f9OBL/TAbwOFBJL79FoS9UKUmnp82RWnhlwTgrAJeMq7lytHhe0Jzc6/P7Zq0+2oviXJuPlvkZalWUug9gg==
 
 camelize@^1.0.0:
   version "1.0.0"
@@ -2423,9 +2423,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000918, caniuse-lite@^1.0.30000929, caniuse-lite@^1.0.30000939:
-  version "1.0.30000939"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000939.tgz#b9ab7ac9e861bf78840b80c5dfbc471a5cd7e679"
-  integrity sha512-oXB23ImDJOgQpGjRv1tCtzAvJr4/OvrHi5SO2vUgB0g0xpdZZoA/BxfImiWfdwoYdUTtQrPsXsvYU/dmCSM8gg==
+  version "1.0.30000940"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000940.tgz#19f2b1497fbfa5b96b615963097c3757f27989ce"
+  integrity sha512-rp/086IBUfCsNgBpko6DGQv674jRjeXPesDatDB2kxrkmDfD+S5Gesw+uT8YjpRWvLKLMRBy72SLRZ8I0EgQFw==
 
 capture-exit@^1.2.0:
   version "1.2.0"
@@ -2909,7 +2909,7 @@ core-js@2.6.4:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.4.tgz#b8897c062c4d769dd30a0ac5c73976c47f92ea0d"
   integrity sha512-05qQ5hXShcqGkPZpXEFLIpxayZscVD2kuMBZewxiIPPEagukO4mqgPA9CWhUvFBJfy3ODdK2p9xyHh7FTU9/7A==
 
-core-js@^2.4.0, core-js@^2.5.0:
+core-js@^2.4.0, core-js@^2.5.0, core-js@^2.5.7:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
@@ -5287,6 +5287,16 @@ hoek@4.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
   integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
 
+hoek@5.x.x:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.4.tgz#0f7fa270a1cafeb364a4b2ddfaa33f864e4157da"
+  integrity sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==
+
+hoek@6.x.x:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.2.tgz#99e6d070561839de74ee427b61aa476bd6bddfd6"
+  integrity sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==
+
 hoist-non-react-statics@^2.5.0, hoist-non-react-statics@^2.5.4:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
@@ -6538,6 +6548,15 @@ joi@^11.1.1:
     hoek "4.x.x"
     isemail "3.x.x"
     topo "2.x.x"
+
+joi@^13.0.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-13.7.0.tgz#cfd85ebfe67e8a1900432400b4d03bbd93fb879f"
+  integrity sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==
+  dependencies:
+    hoek "5.x.x"
+    isemail "3.x.x"
+    topo "3.x.x"
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -9769,7 +9788,7 @@ request@2.87.0:
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
 
-request@^2.79.0, request@^2.87.0:
+request@^2.79.0, request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -9938,6 +9957,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   integrity sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=
   dependencies:
     aproba "^1.1.1"
+
+rx@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
+  integrity sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=
 
 rxjs@^5.0.0-beta.11:
   version "5.5.12"
@@ -11110,6 +11134,13 @@ topo@2.x.x:
   dependencies:
     hoek "4.x.x"
 
+topo@3.x.x:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/topo/-/topo-3.0.3.tgz#d5a67fb2e69307ebeeb08402ec2a2a6f5f7ad95c"
+  integrity sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==
+  dependencies:
+    hoek "6.x.x"
+
 tough-cookie@^2.3.3, tough-cookie@^2.3.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -11532,6 +11563,17 @@ w3c-hr-time@^1.0.1:
   integrity sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=
   dependencies:
     browser-process-hrtime "^0.1.2"
+
+wait-on@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-3.2.0.tgz#c83924df0fc42a675c678324c49c769d378bcb85"
+  integrity sha512-QUGNKlKLDyY6W/qHdxaRlXUAgLPe+3mLL/tRByHpRNcHs/c7dZXbu+OnJWGNux6tU1WFh/Z8aEwvbuzSAu79Zg==
+  dependencies:
+    core-js "^2.5.7"
+    joi "^13.0.0"
+    minimist "^1.2.0"
+    request "^2.88.0"
+    rx "^4.1.0"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
#### Nature of the PR: chore
Attempt to resolve frequent yarn.lock merge conflicts with greenkeeper PR-s.
Switched to Xenial distro on travis. 
Make sure you always use the same yarn version locally as Travis Xenial build. Currently 1.13.0

#### Steps to reproduce:

#### Trello card / screenshot / wireframe link:

#### Is connection necessary to test? If so which network?
- [ ] local RPC
- [ ] Rinkeby
- [ ] Main Ethereum Network
