### PR TITLE
always show success tx

### DIFF
--- a/src/modules/reducers/submittedTransactions.js
+++ b/src/modules/reducers/submittedTransactions.js
@@ -59,7 +59,7 @@ export const updateTx = tx => {
             transactions[tx.transactionHash] = updatedTx;
 
             if (
-                transactions[tx.transactionHash].confirmationNumber === 0 &&
+                transactions[tx.transactionHash].confirmationNumber <= 1 &&
                 transactions[tx.transactionHash].event === "confirmation"
             ) {
                 transactions[tx.transactionHash].isDismissed = undefined;


### PR DESCRIPTION
#### Nature of the PR: bug

#### Steps to reproduce:
Start a transaction. Dismiss popup notifications. Check if successPanel popup become visible.

#### Trello card:
https://trello.com/c/neivtoIU

#### Is connection necessary to test? If so which network?
- [ ] local RPC
- [x] Rinkeby
- [ ] Main Ethereum Network
