### PR TITLE
fix(exchange): fix rate displayed in oder history + change ETH/€ to ETHEUR

### DIFF
--- a/src/components/dashboard/containers/topNav/index.js
+++ b/src/components/dashboard/containers/topNav/index.js
@@ -105,7 +105,7 @@ class TopNav extends React.Component {
                     <StyledTopNavLi>
                         <StyledPrice>
                             <span className="price">
-                                {ETHEUR} {this.props.rates.info.ethFiatRate}
+                                {ETHEUR}: {this.props.rates.info.ethFiatRate}
                             </span>
                         </StyledPrice>
                     </StyledTopNavLi>

--- a/src/components/dashboard/containers/topNav/index.js
+++ b/src/components/dashboard/containers/topNav/index.js
@@ -8,6 +8,7 @@ import ratesProvider from "modules/ratesProvider";
 
 import Icon from "components/augmint-ui/icon";
 import { shortAccountAddresConverter } from "utils/converter";
+import { ETHEUR } from "utils/constants";
 import { CloseIcon } from "./styles";
 import close from "assets/images/close.svg";
 import { theme } from "styles/media";
@@ -103,7 +104,9 @@ class TopNav extends React.Component {
                 <StyledTopNavUl>
                     <StyledTopNavLi>
                         <StyledPrice>
-                            <span className="price">ETH/€ {this.props.rates.info.ethFiatRate}</span>
+                            <span className="price">
+                                {ETHEUR} {this.props.rates.info.ethFiatRate}
+                            </span>
                         </StyledPrice>
                     </StyledTopNavLi>
                     <StyledTopNavLi className={this.props.showAccInfo ? "navLinkRight" : "navLinkRight hidden"}>

--- a/src/containers/exchange/components/ExchangeSummary.js
+++ b/src/containers/exchange/components/ExchangeSummary.js
@@ -2,6 +2,7 @@ import React from "react";
 import { Pblock } from "components/PageLayout";
 import { NoOrdersToolTip } from "./ExchangeToolTips";
 import { ConnectionStatus } from "components/MsgPanels";
+import { ETHEUR } from "utils/constants";
 
 export default class ExchangeSummary extends React.Component {
     render() {
@@ -10,7 +11,7 @@ export default class ExchangeSummary extends React.Component {
             <Pblock loading={rates.isLoading} {...other}>
                 <ConnectionStatus contract={rates} />
 
-                {rates.isLoaded ? <p>1 ETH = {rates.info.ethFiatRate} A-EUR</p> : <h5>Loading ETH/EUR rates...</h5>}
+                {rates.isLoaded ? <p>1 ETH = {rates.info.ethFiatRate} A-EUR</p> : <h5>Loading {ETHEUR} rates...</h5>}
 
                 <ConnectionStatus contract={exchange} />
 

--- a/src/containers/exchange/components/ExchangeToolTips.js
+++ b/src/containers/exchange/components/ExchangeToolTips.js
@@ -1,5 +1,6 @@
 import React from "react";
 import ToolTip from "components/toolTip";
+import { ETHEUR } from "utils/constants";
 
 export function NoOrdersToolTip(props) {
     return (
@@ -14,7 +15,7 @@ export function NoOrdersToolTip(props) {
 export function PriceToolTip(props) {
     return (
         <ToolTip header="Order price" id={"price_tooltip"}>
-            % of published ETH/EUR price. <br /> The actual price will be calculated based on the rate published by
+            % of published {ETHEUR} price. <br /> The actual price will be calculated based on the rate published by
             Augmint at the time of the matching executed. The published price is calculated as an avarage rate from
             multiple exchanges.
         </ToolTip>

--- a/src/containers/exchange/components/MyOrders.js
+++ b/src/containers/exchange/components/MyOrders.js
@@ -9,7 +9,7 @@ import CancelOrderButton from "./CancelOrderButton";
 import BigNumber from "bignumber.js";
 
 import { TOKEN_SELL, TOKEN_BUY } from "modules/reducers/orders";
-import { DECIMALS } from "utils/constants";
+import { DECIMALS, ETHEUR } from "utils/constants";
 import { floatNumberConverter } from "utils/converter";
 
 const OrderItem = props => {
@@ -48,16 +48,16 @@ const OrderItem = props => {
                     {order.direction === TOKEN_SELL && (
                         <p>
                             Sell A€ order: <br />
-                            {order.amount} A€ @{displayPrice}% of current ETH/€ = <br />
-                            {order.amount} A€ * {order.price} €/A€ / {ethFiatRate} €/ETH = <br />
+                            {order.amount} A€ @{displayPrice}% of current {ETHEUR} = <br />
+                            {order.amount} A€ * {order.price} €/A€ / {ethFiatRate} {ETHEUR} = <br />
                             {actualValue} ETH
                         </p>
                     )}
                     {order.direction === TOKEN_BUY && (
                         <p>
                             Buy A€ Order: <br />
-                            {order.amount} ETH @{displayPrice}% of current ETH/€ = <br />
-                            {order.amount} ETH * {ethFiatRate} €/ETH / {order.price} €/A€ = <br />
+                            {order.amount} ETH @{displayPrice}% of current {ETHEUR} = <br />
+                            {order.amount} ETH * {ethFiatRate} {ETHEUR} / {order.price} €/A€ = <br />
                             {actualValue} A€
                         </p>
                     )}

--- a/src/containers/exchange/components/OrderBook.js
+++ b/src/containers/exchange/components/OrderBook.js
@@ -11,7 +11,7 @@ import BigNumber from "bignumber.js";
 import styled from "styled-components";
 
 import { TOKEN_SELL, TOKEN_BUY } from "modules/reducers/orders";
-import { DECIMALS, DECIMALS_DIV } from "utils/constants";
+import { DECIMALS, DECIMALS_DIV, ETHEUR } from "utils/constants";
 import { floatNumberConverter } from "utils/converter";
 
 const StyledSpan = styled.span`
@@ -59,16 +59,16 @@ const OrderItem = props => {
                 {order.direction === TOKEN_SELL && (
                     <p>
                         Sell A€ order: <br />
-                        {order.amount} A€ @{displayPrice}% of current ETH/€ = <br />
-                        {order.amount} A€ * {order.price} €/A€ / {ethFiatRate} €/ETH = <br />
+                        {order.amount} A€ @{displayPrice}% of current {ETHEUR} = <br />
+                        {order.amount} A€ * {order.price} €/A€ / {ethFiatRate} {ETHEUR} = <br />
                         {actualValue} ETH
                     </p>
                 )}
                 {order.direction === TOKEN_BUY && (
                     <p>
                         Buy A€ Order: <br />
-                        {order.amount} ETH @{displayPrice}% of current ETH/€ = <br />
-                        {order.amount} ETH * {ethFiatRate} €/ETH / {order.price} €/A€ = <br />
+                        {order.amount} ETH @{displayPrice}% of current {ETHEUR} = <br />
+                        {order.amount} ETH * {ethFiatRate} {ETHEUR} / {order.price} €/A€ = <br />
                         {actualValue} A€
                     </p>
                 )}
@@ -85,7 +85,7 @@ const OrderItem = props => {
 const OrderList = props => {
     const { sellOrders, buyOrders, userAccountAddress, ethFiatRate, orderDirection } = props;
 
-    const totalEthBuyAmount = parseFloat(buyOrders.reduce((sum, order) => order.bn_ethValue.add(sum), 0).toFixed(5));
+    const totalEthBuyAmount = parseFloat(buyOrders.reduce((sum, order) => order.bn_ethValue.add(sum), 0)).toFixed(5);
     const totalEthSellAmount = sellOrders
         .reduce((sum, order) => new BigNumber(((order.amount * order.price) / ethFiatRate).toFixed(5)).add(sum), 0)
         .toFixed(5);
@@ -135,7 +135,7 @@ const OrderList = props => {
                     <PriceToolTip id={orderDirection === TOKEN_SELL ? "price_sell" : "price_buy"} />
                 </Col>
                 <Col style={{ textAlign: "right" }} width={3}>
-                    <strong>Est. ETH/€ rate</strong>
+                    <strong>Est. {ETHEUR}</strong>
                 </Col>
                 <Col width={2} style={{ padding: ".1em 0 0 5px" }} />
             </Row>

--- a/src/containers/exchange/components/TradeHistory.js
+++ b/src/containers/exchange/components/TradeHistory.js
@@ -4,6 +4,8 @@ import { Pblock } from "components/PageLayout";
 import { ErrorPanel } from "components/MsgPanels";
 import { CustomTable } from "components/Table";
 
+import { ETHEUR } from "utils/constants";
+
 export default class TradeHistory extends React.Component {
     render() {
         const { header } = this.props;
@@ -27,7 +29,7 @@ export default class TradeHistory extends React.Component {
             pricePt: "Price",
             ethAmountRounded: "Eth Amount",
             tokenAmount: "Token Amount",
-            publishedRate: "ETH/€ rate"
+            publishedRate: ETHEUR + " rate"
         };
 
         return (

--- a/src/containers/exchange/components/TradeHistory.js
+++ b/src/containers/exchange/components/TradeHistory.js
@@ -22,14 +22,14 @@ export default class TradeHistory extends React.Component {
         ];
         const unit = ["", "", "", "", "", "ETH", "A€", "A€", ""];
         const headerData = {
-            orderId: "Order ID",
+            orderId: "ID",
             blockTimeStampText: "Date",
             type: "Type",
             direction: "Direction",
             pricePt: "Price",
             ethAmountRounded: "Eth Amount",
-            tokenAmount: "Token Amount",
-            effectiveRate: "Effective ETHEUR RATE"
+            tokenAmount: "A€ Amount",
+            effectiveRate: ETHEUR + " RATE"
         };
 
         return (

--- a/src/containers/exchange/components/TradeHistory.js
+++ b/src/containers/exchange/components/TradeHistory.js
@@ -18,9 +18,9 @@ export default class TradeHistory extends React.Component {
             "pricePt",
             "ethAmountRounded",
             "tokenAmount",
-            "publishedRate"
+            "effectiveRate"
         ];
-        const unit = ["", "", "", "", "", "ETH", "A€", "A€"];
+        const unit = ["", "", "", "", "", "ETH", "A€", "A€", ""];
         const headerData = {
             orderId: "Order ID",
             blockTimeStampText: "Date",
@@ -29,7 +29,7 @@ export default class TradeHistory extends React.Component {
             pricePt: "Price",
             ethAmountRounded: "Eth Amount",
             tokenAmount: "Token Amount",
-            publishedRate: ETHEUR + " rate"
+            effectiveRate: "Effective ETHEUR RATE"
         };
 
         return (

--- a/src/containers/loan/components/LoanToolTips.js
+++ b/src/containers/loan/components/LoanToolTips.js
@@ -1,11 +1,13 @@
 import React from "react";
 import ToolTip from "components/toolTip";
+import { ETHEUR } from "utils/constants";
 
 export function LoanInterestRatePaToolTip(props) {
     return (
         <ToolTip header="Loan Interest per Annum" id={"loan_interest_rate"}>
             The annualised interest rate of the loan. It's calculated using a simple (non-compound) method and with a
-            365 day year.<br />
+            365 day year.
+            <br />
             Note: For small loan amounts the actual interest percent can slightly differ than displayed (~0.01 A-EUR
             difference in interest amount due to rounding )
         </ToolTip>
@@ -16,8 +18,10 @@ export function DiscountRateToolTip(props) {
     // not shown on UI anymore, kept for future reference
     return (
         <ToolTip header="Discount Rate" id={"discount_rate"}>
-            Disbursed A-EUR amount / amount due on maturity.<br />
-            E.g. Disbursed loan amount is 100 A-EUR and discount rate is {props.discountRate * 100}% then<br />
+            Disbursed A-EUR amount / amount due on maturity.
+            <br />
+            E.g. Disbursed loan amount is 100 A-EUR and discount rate is {props.discountRate * 100}% then
+            <br />
             {Math.round(10000 / props.discountRate) / 100} A-EUR will be repayable.
         </ToolTip>
     );
@@ -26,12 +30,12 @@ export function DiscountRateToolTip(props) {
 export function LoanCollateralRatioToolTip(props) {
     return (
         <ToolTip header="Loan/collateral ratio" id={"loan_collateral_ratio"}>
-            A-EUR loan amount / EUR value of ETH collateral.<br />
-            I.e. How much A-EUR loan can you get for your ETH<br />
-            E.g. 1ETH worth 200 EUR and the Loan/Collateral ratio is {props.collateralRatio}% then you can get ~{Math.round(
-                props.loanCollateralRatio * 20000
-            ) / 100}{" "}
-            A-EUR for 1 ETH placed in escrow.
+            A-EUR loan amount / EUR value of ETH collateral.
+            <br />
+            I.e. How much A-EUR loan can you get for your ETH
+            <br />
+            E.g. 1ETH worth 200 EUR and the Loan/Collateral ratio is {props.collateralRatio}% then you can get ~
+            {Math.round(props.loanCollateralRatio * 20000) / 100} A-EUR for 1 ETH placed in escrow.
         </ToolTip>
     );
 }
@@ -40,14 +44,18 @@ export function DefaultingFeeTooltip(props) {
     return (
         <ToolTip header="Defaulting fee" id={"defaulting_fee"}>
             If you don't repay your loan on maturity then the system will calculate the ETH collateral required to cover
-            your A-EUR repayment due. It will use the ETH/EUR rates at moment of the collection executed.<br />
+            your A-EUR repayment due. It will use the {ETHEUR} rates at moment of the collection executed.
+            <br />
             It will add a percentage of your repayment amount as fee. The leftover collateral ETH (if any) will be sent
             back to your account.
             <br />
             <small>
-                E.g. 1 ETH worth 200 EUR at the moment of collection and the defaulting fee is 5%.<br />
-                You don't repay 200 A-EUR with 2 ETH in escrow.<br />
-                To cover you missed repayment 1 ETH + 0.05ETH (5% of 200 A-EUR) is required.<br />
+                E.g. 1 ETH worth 200 EUR at the moment of collection and the defaulting fee is 5%.
+                <br />
+                You don't repay 200 A-EUR with 2 ETH in escrow.
+                <br />
+                To cover you missed repayment 1 ETH + 0.05ETH (5% of 200 A-EUR) is required.
+                <br />
                 The collector will send you back 0.95 ETH and will take 1.05 ETH into the Augmint reserves.
             </small>
         </ToolTip>

--- a/src/containers/loan/newLoan/NewLoanForm.js
+++ b/src/containers/loan/newLoan/NewLoanForm.js
@@ -16,7 +16,7 @@ import { Pgrid } from "components/PageLayout";
 
 import theme from "styles/theme";
 
-import { ONE_ETH_IN_WEI, PPM_DIV } from "utils/constants";
+import { ONE_ETH_IN_WEI, PPM_DIV, ETHEUR } from "utils/constants";
 
 const ETH_DECIMALS = 5;
 const TOKEN_DECIMALS = 2;
@@ -185,7 +185,7 @@ class NewLoanForm extends React.Component {
                     />
                 )}
                 {!isRatesAvailable && (
-                    <ErrorPanel>No ETH/EUR rates available. Can't get a loan at the moment. Try agin later</ErrorPanel>
+                    <ErrorPanel>No {ETHEUR} rates available. Can't get a loan at the moment. Try agin later</ErrorPanel>
                 )}
                 {isRatesAvailable && (
                     <Form onSubmit={handleSubmit(onSubmit)}>
@@ -228,9 +228,9 @@ class NewLoanForm extends React.Component {
                                     <label>
                                         ETH amount to collateral
                                         <ToolTip id={"collateral"}>
-                                            ETH to be held as collateral = A-EUR Loan Amount / ETHEUR rate x (1 /
+                                            ETH to be held as collateral = A-EUR Loan Amount / {ETHEUR} rate x (1 /
                                             Coverage ratio)
-                                            <br />( ETH/EUR Rate ={" "}
+                                            <br />( {ETHEUR} Rate ={" "}
                                             {Math.round(this.props.rates.info.ethFiatRate * 100) / 100} )
                                         </ToolTip>
                                     </label>

--- a/src/containers/underthehood/components/RatesInfo.js
+++ b/src/containers/underthehood/components/RatesInfo.js
@@ -3,6 +3,7 @@ import store from "modules/store";
 import { Pblock } from "components/PageLayout";
 import { ContractBaseInfo } from "./ContractBaseInfo";
 import { refreshRates } from "modules/reducers/rates";
+import { ETHEUR } from "utils/constants";
 
 export function RatesInfo(props) {
     const { contractData } = props;
@@ -14,7 +15,9 @@ export function RatesInfo(props) {
 
     return (
         <Pblock header="Rates">
-            <p>ETH/EUR: {contractData.info.ethFiatRate}</p>
+            <p>
+                {ETHEUR}: {contractData.info.ethFiatRate}
+            </p>
 
             <ContractBaseInfo refreshCb={handleRefreshClick} {...props} />
         </Pblock>

--- a/src/modules/ethereum/tradeTransactions.js
+++ b/src/modules/ethereum/tradeTransactions.js
@@ -60,6 +60,7 @@ async function _formatTradeLog(account, txData, args, type) {
     const tokenAmount = parseFloat(bn_tokenAmount / DECIMALS_DIV);
     const price = parseFloat(args.price / PPM_DIV);
     const publishedRate = args.publishedRate && parseFloat(args.publishedRate / DECIMALS_DIV).toFixed(2);
+    const effectiveRate = args.publishedRate && parseFloat((args.publishedRate / DECIMALS_DIV) * price).toFixed(2);
 
     let orderId;
     if (args.orderId) {
@@ -89,6 +90,7 @@ async function _formatTradeLog(account, txData, args, type) {
         price: price ? price : "",
         pricePt: price ? floatNumberConverter(price, DECIMALS).toFixed(2) + "%" : "",
         publishedRate,
+        effectiveRate,
         orderId,
         type: txData.event
     });

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -8,6 +8,8 @@ export const DECIMALS = 2;
 
 export const PPM_DIV = 1000000;
 
+export const ETHEUR = "ETHEUR";
+
 /* used for newer contracts where CHUNK_SIZE is a param for query fxs.
     for older contracts CHUNK_SIZE available via contracts getters but we don't use those anymore (won't change chunkSize in legacy contracts)  */
 export const LEGACY_CONTRACTS_CHUNK_SIZE = 100; // Chunksize how legacy contracts were deployed (can't be changed here!)


### PR DESCRIPTION
#### Nature of the PR: bug
#### Steps to reproduce:
go to /exchange
#### screenshot:
- change ETH/€ to ETHEUR
- and correct the (effective) rate:
![image](https://user-images.githubusercontent.com/32713470/54145103-8fe6de80-442d-11e9-9d00-8ab2b4273607.png)


#### Is connection necessary to test? If so which network?
- [ ] local RPC
- [x] Rinkeby
- [x] Main Ethereum Network
