### PR TITLE
loan & lock products interest rate rounding fix on stability dashboard

### DIFF
--- a/src/containers/augmintToken/index.js
+++ b/src/containers/augmintToken/index.js
@@ -127,9 +127,7 @@ class AugmintToken extends React.Component {
                         {product.isActive && (
                             <StyledRow halign="justify">
                                 <StyledCol width={1 / 2}>{product.termText}</StyledCol>
-                                <StyledCol width={1 / 2}>
-                                    {Math.floor(product.interestRatePa * 10000) / 100 + "%"}
-                                </StyledCol>
+                                <StyledCol width={1 / 2}>{product.interestRatePaPt}%</StyledCol>
                             </StyledRow>
                         )}
                     </div>
@@ -153,9 +151,7 @@ class AugmintToken extends React.Component {
                                 <StyledCol width={1 / 2} className="alignLeft">
                                     {product.durationText}
                                 </StyledCol>
-                                <StyledCol width={1 / 2}>
-                                    {Math.floor(product.interestRatePa * 10000) / 100 + "%"}
-                                </StyledCol>
+                                <StyledCol width={1 / 2}>{product.interestRatePaPt}%</StyledCol>
                             </StyledRow>
                         )}
                     </div>

--- a/src/containers/loan/components/LoanProductDetails.js
+++ b/src/containers/loan/components/LoanProductDetails.js
@@ -27,11 +27,11 @@ export default function LoanProductDetails(props) {
                 <Col>
                     Interest p.a.:{" "}
                     <LoanInterestRatePaToolTip
-                        interestRatePa={prod.interestRatePa}
+                        interestRatePaPt={prod.interestRatePaPt}
                         id={"Loan_interest_rate_pa_tooltip"}
                     />
                 </Col>
-                <Col>{Math.round(prod.interestRatePa * 10000) / 100}%</Col>
+                <Col>{prod.interestRatePaPt}%</Col>
             </Row>
             <Row>
                 <Col>

--- a/src/containers/lock/components/LockDetails.js
+++ b/src/containers/lock/components/LockDetails.js
@@ -14,7 +14,7 @@ export default function LockDetails(props) {
             <Row>
                 <Col>Interest amount:</Col>
                 <Col>
-                    {lock.interestEarned} A-EUR ({(lock.interestRatePa * 100).toFixed(2)} % p.a)
+                    {lock.interestEarned} A-EUR ({lock.interestRatePaPt} % p.a)
                 </Col>
             </Row>
 

--- a/src/containers/lock/containers/LockForm/index.js
+++ b/src/containers/lock/containers/LockForm/index.js
@@ -173,9 +173,7 @@ class LockContainer extends React.Component {
                                                     <TermTableCell>
                                                         {Math.floor(product.maxLockAmount)} A€
                                                     </TermTableCell>
-                                                    <TermTableCell>
-                                                        {Math.floor(product.interestRatePa * 10000) / 100} %
-                                                    </TermTableCell>
+                                                    <TermTableCell>{product.interestRatePaPt} %</TermTableCell>
                                                     <TermTableCell style={{ textAlign: "right" }}>
                                                         {this.props.lockAmount &&
                                                             `${Math.ceil(

--- a/src/containers/lock/lockList/LockCard.js
+++ b/src/containers/lock/lockList/LockCard.js
@@ -115,7 +115,7 @@ export default function LockCard(props) {
                             <DataRow>
                                 <DataLabel>Interest amount:</DataLabel>
                                 <DataValue>
-                                    {lock.interestEarned} A-EUR ({(lock.interestRatePa * 100).toFixed(2)} % p.a)
+                                    {lock.interestEarned} A-EUR ({lock.interestRatePa} % p.a)
                                 </DataValue>
                             </DataRow>
                         </DataGroup>

--- a/src/modules/ethereum/loanTransactions.js
+++ b/src/modules/ethereum/loanTransactions.js
@@ -88,6 +88,7 @@ function parseProducts(productsArray) {
                 termText: moment.duration(termInSecs, "seconds").humanize(), // TODO: less precision for duration: https://github.com/jsmreese/moment-duration-format
                 bn_discountRate,
                 interestRatePa,
+                interestRatePaPt: Math.round(interestRatePa * 10000) / 100,
                 discountRate,
                 bn_collateralRatio,
                 collateralRatio: bn_collateralRatio / PPM_DIV,
@@ -191,8 +192,8 @@ export async function collectLoansTx(loanManagerInstance, loansToCollect) {
             typeof receipt.events.LoanCollected === "undefined"
                 ? 0
                 : Array.isArray(receipt.events.LoanCollected)
-                    ? receipt.events.LoanCollected.length
-                    : 1;
+                ? receipt.events.LoanCollected.length
+                : 1;
 
         if (loanCollectedEventsCount !== loansToCollect.length) {
             throw new EthereumTransactionError(

--- a/src/modules/ethereum/lockTransactions.js
+++ b/src/modules/ethereum/lockTransactions.js
@@ -52,7 +52,8 @@ function parseProducts(productsArray) {
                 minimumLockAmount: bn_minimumLockAmount / DECIMALS_DIV,
                 maxLockAmount: bn_maxLockAmount / DECIMALS_DIV,
                 interestRatePa,
-                interestRatePaPt: Math.round(interestRatePa * 10000) / 100,
+                // using floor for the "advertised" interest rate to ensure that the actual interest will be higher even with small amount
+                interestRatePaPt: Math.floor(interestRatePa * 10000) / 100,
                 isActive: parseInt(bn_isActive, 10) === 1
             });
         }
@@ -183,6 +184,7 @@ function parseLocks(locksArray) {
                 lockedUntilText,
                 perTermInterest,
                 interestRatePa,
+                // this is the actual interest rate (can be higher than advertised because of rounding up in contract code)
                 interestRatePaPt: Math.round(interestRatePa * 10000) / 100,
                 durationInSecs,
                 durationInDays,

--- a/src/modules/ethereum/lockTransactions.js
+++ b/src/modules/ethereum/lockTransactions.js
@@ -52,6 +52,7 @@ function parseProducts(productsArray) {
                 minimumLockAmount: bn_minimumLockAmount / DECIMALS_DIV,
                 maxLockAmount: bn_maxLockAmount / DECIMALS_DIV,
                 interestRatePa,
+                interestRatePaPt: Math.round(interestRatePa * 10000) / 100,
                 isActive: parseInt(bn_isActive, 10) === 1
             });
         }
@@ -182,6 +183,7 @@ function parseLocks(locksArray) {
                 lockedUntilText,
                 perTermInterest,
                 interestRatePa,
+                interestRatePaPt: Math.round(interestRatePa * 10000) / 100,
                 durationInSecs,
                 durationInDays,
                 durationText,


### PR DESCRIPTION
#### Nature of the PR: bug
Fixed interest pa. calculation for loan products on stability dashboard. 
Also refactored that interest p.a. % is calculated by reducers (`interestRatePaPt`) for both loan and lock products, saved to store and all components are using that instead of each calculating with their own formula.

#### Steps to reproduce:
Interest rate for lock is incorrectly rounded on stability dashboard
![image](https://user-images.githubusercontent.com/7456451/55006915-6950a800-4fd6-11e9-900d-3a37635ffe6b.png)

#### Is connection necessary to test? If so which network?
- [ ] local RPC
- [x] Rinkeby
- [x] Main Ethereum Network
