### PR TITLE
fix lock interest pa. display

### DIFF
--- a/src/containers/lock/lockList/LockCard.js
+++ b/src/containers/lock/lockList/LockCard.js
@@ -115,7 +115,7 @@ export default function LockCard(props) {
                             <DataRow>
                                 <DataLabel>Interest amount:</DataLabel>
                                 <DataValue>
-                                    {lock.interestEarned} A-EUR ({lock.interestRatePa} % p.a)
+                                    {lock.interestEarned} A-EUR ({lock.interestRatePaPt} % p.a)
                                 </DataValue>
                             </DataRow>
                         </DataGroup>


### PR DESCRIPTION
#### Nature of the PR: bug
#### Steps to reproduce:
Lock interest displayed incorrectly on lock card

#### Trello card / screenshot / wireframe link:
![image](https://user-images.githubusercontent.com/7456451/55165764-e1010d00-5165-11e9-94b1-75b467893ff0.png)

