### PR TITLE
fix calculateMatchingOrders return when no orders (didn't aff. UI)

### DIFF
--- a/src/modules/ethereum/exchangeTransactions.Matching.test.js
+++ b/src/modules/ethereum/exchangeTransactions.Matching.test.js
@@ -11,7 +11,7 @@ describe("getMatchingOrders", () => {
         const matches = calculateMatchingOrders([], [], ETHEUR_RATE, GAS_LIMIT);
         expect(matches.buyIds).toHaveLength(0);
         expect(matches.sellIds).toHaveLength(0);
-        expect(matches.gasEstimate).toBeUndefined();
+        expect(matches.gasEstimate).toBe(0);
     });
 
     test("should return empty arrays if no matching orders", () => {

--- a/src/modules/ethereum/exchangeTransactions.Matching.test.js
+++ b/src/modules/ethereum/exchangeTransactions.Matching.test.js
@@ -7,10 +7,11 @@ describe("getMatchingOrders", () => {
     const BN_ONE = new BigNumber(1);
     const GAS_LIMIT = Number.MAX_SAFE_INTEGER;
 
-    test("should return no match if no orders", () => {
-        const [buyIds, sellIds] = calculateMatchingOrders([], [], ETHEUR_RATE, GAS_LIMIT);
-        expect(sellIds).toHaveLength(0);
-        expect(buyIds).toHaveLength(0);
+    test("should return no empty arrays if no orders", () => {
+        const matches = calculateMatchingOrders([], [], ETHEUR_RATE, GAS_LIMIT);
+        expect(matches.buyIds).toHaveLength(0);
+        expect(matches.sellIds).toHaveLength(0);
+        expect(matches.gasEstimate).toBeUndefined();
     });
 
     test("should return empty arrays if no matching orders", () => {

--- a/src/modules/ethereum/exchangeTransactions.js
+++ b/src/modules/ethereum/exchangeTransactions.js
@@ -231,7 +231,7 @@ export function calculateMatchingOrders(_buyOrders, _sellOrders, bn_ethFiatRate,
     const buyIds = [];
 
     if (_buyOrders.length === 0 || _sellOrders.length === 0) {
-        return { buyIds, sellIds };
+        return { buyIds, sellIds, gasEstimate: 0 };
     }
     const lowestSellPrice = _sellOrders[0].price;
     const highestBuyPrice = _buyOrders[0].price;

--- a/src/modules/ethereum/exchangeTransactions.js
+++ b/src/modules/ethereum/exchangeTransactions.js
@@ -231,7 +231,7 @@ export function calculateMatchingOrders(_buyOrders, _sellOrders, bn_ethFiatRate,
     const buyIds = [];
 
     if (_buyOrders.length === 0 || _sellOrders.length === 0) {
-        return [buyIds, sellIds];
+        return { buyIds, sellIds };
     }
     const lowestSellPrice = _sellOrders[0].price;
     const highestBuyPrice = _buyOrders[0].price;


### PR DESCRIPTION
#### Nature of the PR: chore
calculateMatchingOrders fx returned values in inconsistent format  in case when were no orders on any side of the OrderBook. 
It didn't affect the UI because the match orders button is not shown when there are no orders.

#### Steps to reproduce:
N/A