### PR TITLE
fix(travis & cypress): change yarn to don't run record

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   - wait-on tcp:localhost:8545 # ganache
 script:
   - yarn test # jest tests
-  - yarn cypress:runrecord
+  - yarn cypress:run
 after_script: greenkeeper-lockfile-upload
 # discord webhooks hack until this is released: https://github.com/travis-ci/travis-tasks/pull/71
 after_success:


### PR DESCRIPTION
#### Nature of the PR: chore
#### Steps to reproduce:
- travis builds fail bc cypress runs with `runrecord` but can not record more sessions 

#### Screenshot:
![image](https://user-images.githubusercontent.com/32713470/56147831-4b5cde80-5fa9-11e9-9c21-b2ee4490e5f8.png)

#### Is connection necessary to test? If so which network?
- [ ] local RPC
- [ ] Rinkeby
- [ ] Main Ethereum Network
