### PR TITLE
Change transfer-aeur naming

### DIFF
--- a/src/components/dashboard/components/sideNav/index.js
+++ b/src/components/dashboard/components/sideNav/index.js
@@ -208,7 +208,7 @@ export default class SiteNav extends React.Component {
                     <SideNavLi>
                         <SideNavLink to="/transfer" activeClassName="active" data-testid="trasnferMenuLink">
                             <Icon name="send" />
-                            <span>Send</span>
+                            <span>Send A-EUR</span>
                         </SideNavLink>
                     </SideNavLi>
                     <SideNavLi>

--- a/src/containers/transfer/index.js
+++ b/src/containers/transfer/index.js
@@ -46,7 +46,7 @@ class TransferPage extends React.Component {
             <EthereumState>
                 <Psegment>
                     <TopNavTitlePortal>
-                        <Pheader header="Transfer A-EUR" />
+                        <Pheader header="Send A-EUR" />
                     </TopNavTitlePortal>
 
                     <NoTokenAlert style={{ margin: "0 15px 5px" }} />

--- a/src/containers/transfer/request/ShowTransferRequest.js
+++ b/src/containers/transfer/request/ShowTransferRequest.js
@@ -139,7 +139,7 @@ class ShowTransferRequest extends React.Component {
                                                             <b>Warning:</b> you are making a transfer to an address
                                                             provided by an external site. Make sure the address belongs
                                                             to {request.beneficiary_name}
-                                                            who you are really willing to transfer A-EUR. Funds sent to
+                                                            who you are really willing to send A-EUR. Funds sent to
                                                             wrong address might be lost irreversibly.
                                                         </i>
                                                     </small>


### PR DESCRIPTION
#### Nature of the PR: bug
#### Steps to reproduce:

#### Trello card / screenshot / wireframe link:
change "Transfer A-EUR" to "Send A-EUR"
& add it to the menu...

#### Is connection necessary to test? If so which network?
- [ ] local RPC
- [x] Rinkeby
- [ ] Main Ethereum Network
