### PR TITLE
update CANCEL_ORDER_GAS estimate

### DIFF
--- a/src/modules/ethereum/gas.js
+++ b/src/modules/ethereum/gas.js
@@ -24,8 +24,11 @@ export const cost = {
     MATCH_MULTIPLE_ADDITIONAL_MATCH_GAS: 50000,
 
     // actuals on ganache: sell cancel: 31891-43725 / buy cancel: 24264-28470
-    //    last sell order cancel reverts in ganache with 60000 gas limit despite it runs w/ 31891 gas... likely a ganache bug
-    CANCEL_ORDER_GAS: 70000,
+    //  last sell order cancel reverts in ganache with 60000 gas limit despite it runs w/ 31891 gas... 
+    //  similar with  on rinkeby:  
+    //    reverts with 70k gaslimit: https://rinkeby.etherscan.io/tx/0xd88c7cd447a2365ce328951c07b63b6bf359571e9900c59212678734bff9deee
+    //     then succeeds with 90k but consumes ony 55,897 : https://rinkeby.etherscan.io/tx/0x98117244f7a1c015529ac8d310894bdf7c7aa82c8834b9da437b5932f13847a5
+    CANCEL_ORDER_GAS: 100000,
 
     LEGACY_BALANCE_CONVERT_GAS: 200000,
 


### PR DESCRIPTION
increased gas estimate from 70k to 100k due to occasionally running out of gas on rinkeby (see links in comments)

#### Nature of the PR: bug/feature/chore
#### Steps to reproduce:

#### Trello card / screenshot / wireframe link:

#### Is connection necessary to test? If so which network?
- [ ] local RPC
- [ ] Rinkeby
- [ ] Main Ethereum Network
