### PR TITLE
fix(sideNav): logo padding issue

### DIFF
--- a/src/components/dashboard/components/sideNav/index.js
+++ b/src/components/dashboard/components/sideNav/index.js
@@ -59,6 +59,10 @@ export const SideNav = styled.nav`
         `};
     }
 
+    ${media.desktopMin`
+        padding-top: 20px;
+    `}
+
     &.opened {
         ${mediaopacity.handheld`opacity: .97`} width: 100%;
     }


### PR DESCRIPTION
fixes small padding issue of the logo on desktop:

![image](https://user-images.githubusercontent.com/32713470/59847919-251a3d00-9364-11e9-8b3f-ffd7f295570a.png)
