### PR TITLE
increase gas limit offered for repay

### DIFF
--- a/src/modules/ethereum/gas.js
+++ b/src/modules/ethereum/gas.js
@@ -1,7 +1,7 @@
 export const cost = {
     NEW_LOAN_GAS: 240000, // As of now it's on ganache: 167,196-167390 - 182,000???
     NEW_FIRST_LOAN_GAS: 240000, // 227390
-    REPAY_GAS: 150000, // AugmintToken.transferAndNotify, as of now on testRpc: first: 105,354, tehn : 120305 ?
+    REPAY_GAS: 250000, // AugmintToken.transferAndNotify, as of now on testRpc: first: 105,354, tehn : 120305 ?
     COLLECT_BASE_GAS: 90000, // as of now on testRpc: 1 loan = first: 73,333, consecutive:  64,683
     COLLECT_ONE_GAS: 20000, // as of now: ca. 10000
 


### PR DESCRIPTION
increased default gas limit to 250k for repay because 150k gas limit is not enough recently, [repay tx fails](https://etherscan.io/tx/0x6f82dbaef1ab74c515b0205debfa1c2b04c96d4bc911c59f0590b538db0b4f63) 

[tx succeeds](https://etherscan.io/tx/0xa955dd7e2f3948af191ed8912d9a2090fe3ef2971c445b7fddcec4050089a3d7) when gas limit increased but sitll  using only 130k gas.
 `¯\_(ツ)_/¯`